### PR TITLE
Feat: add cost estimation operation

### DIFF
--- a/nodes/AlterLab/AlterLab.node.json
+++ b/nodes/AlterLab/AlterLab.node.json
@@ -1,32 +1,35 @@
 {
-	"node": "n8n-nodes-alterlab.alterLab",
-	"nodeVersion": "1.0",
-	"codexVersion": "1.0",
-	"categories": ["Data & Storage"],
-	"subcategories": {
-		"Data & Storage": ["Web Scraping"]
-	},
-	"resources": {
-		"primaryDocumentation": [
-			{
-				"url": "https://docs.alterlab.io/api?utm_source=n8n&utm_medium=integration&utm_campaign=community_node"
-			}
-		]
-	},
-	"alias": [
-		"scrape",
-		"web scraping",
-		"crawl",
-		"crawler",
-		"extract",
-		"anti-bot",
-		"proxy",
-		"screenshot",
-		"pdf",
-		"ocr",
-		"headless browser",
-		"data extraction",
-		"web data",
-		"scraper"
-	]
+  "node": "n8n-nodes-alterlab.alterLab",
+  "nodeVersion": "1.0",
+  "codexVersion": "1.0",
+  "categories": ["Data & Storage"],
+  "subcategories": {
+    "Data & Storage": ["Web Scraping"]
+  },
+  "resources": {
+    "primaryDocumentation": [
+      {
+        "url": "https://docs.alterlab.io/api?utm_source=n8n&utm_medium=integration&utm_campaign=community_node"
+      }
+    ]
+  },
+  "alias": [
+    "scrape",
+    "web scraping",
+    "crawl",
+    "crawler",
+    "extract",
+    "anti-bot",
+    "proxy",
+    "screenshot",
+    "pdf",
+    "ocr",
+    "headless browser",
+    "data extraction",
+    "web data",
+    "scraper",
+    "cost estimate",
+    "estimate",
+    "pricing"
+  ]
 }

--- a/nodes/AlterLab/AlterLab.node.ts
+++ b/nodes/AlterLab/AlterLab.node.ts
@@ -1,736 +1,889 @@
 import type {
-	IDataObject,
-	IExecuteFunctions,
-	INodeExecutionData,
-	INodeType,
-	INodeTypeDescription,
-	JsonObject,
-} from 'n8n-workflow';
-import { NodeApiError, NodeOperationError } from 'n8n-workflow';
+  IDataObject,
+  IExecuteFunctions,
+  INodeExecutionData,
+  INodeType,
+  INodeTypeDescription,
+  JsonObject,
+} from "n8n-workflow";
+import { NodeApiError, NodeOperationError } from "n8n-workflow";
 
-const UTM = 'utm_source=n8n&utm_medium=integration&utm_campaign=community_node';
+const UTM = "utm_source=n8n&utm_medium=integration&utm_campaign=community_node";
 
 export class AlterLab implements INodeType {
-	description: INodeTypeDescription = {
-		displayName: 'AlterLab',
-		name: 'alterLab',
-		icon: 'file:alterlab.svg',
-		group: ['transform'],
-		version: 1,
-		subtitle: '={{$parameter["mode"] + " scrape"}}',
-		description:
-			'Scrape any website with anti-bot bypass, JS rendering, structured extraction, OCR, and more',
-		defaults: {
-			name: 'AlterLab',
-		},
-		inputs: ['main'],
-		outputs: ['main'],
-		credentials: [
-			{
-				name: 'alterLabApi',
-				displayName: 'API Key',
-			},
-			{
-				name: 'alterLabOAuth2Api',
-				displayName: 'OAuth2 (Recommended)',
-			},
-		],
-		properties: [
-			// ── Primary ──────────────────────────────────────────
-			{
-				displayName: 'URL',
-				name: 'url',
-				type: 'string',
-				default: '',
-				required: true,
-				placeholder: 'https://www.example.com/page',
-				description: 'The URL to scrape',
-			},
-			{
-				displayName: 'Mode',
-				name: 'mode',
-				type: 'options',
-				default: 'auto',
-				options: [
-					{
-						name: 'Auto',
-						value: 'auto',
-						description: 'Automatically choose the best scraping method',
-					},
-					{
-						name: 'HTML',
-						value: 'html',
-						description: 'Fast HTTP-only scraping for static pages',
-					},
-					{
-						name: 'JavaScript',
-						value: 'js',
-						description: 'Render JavaScript with headless browser',
-					},
-					{
-						name: 'PDF',
-						value: 'pdf',
-						description: 'Extract text from PDF documents',
-					},
-					{
-						name: 'OCR',
-						value: 'ocr',
-						description: 'Extract text from images',
-					},
-				],
-				description: 'Scraping mode to use',
-			},
+  description: INodeTypeDescription = {
+    displayName: "AlterLab",
+    name: "alterLab",
+    icon: "file:alterlab.svg",
+    group: ["transform"],
+    version: 1,
+    subtitle:
+      '={{$parameter["operation"] === "estimateCost" ? "cost estimate" : $parameter["mode"] + " scrape"}}',
+    description:
+      "Scrape any website with anti-bot bypass, JS rendering, structured extraction, OCR, and more",
+    defaults: {
+      name: "AlterLab",
+    },
+    inputs: ["main"],
+    outputs: ["main"],
+    credentials: [
+      {
+        name: "alterLabApi",
+        displayName: "API Key",
+      },
+      {
+        name: "alterLabOAuth2Api",
+        displayName: "OAuth2 (Recommended)",
+      },
+    ],
+    properties: [
+      // ── Operation ────────────────────────────────────────
+      {
+        displayName: "Operation",
+        name: "operation",
+        type: "options",
+        noDataExpression: true,
+        default: "scrape",
+        options: [
+          {
+            name: "Scrape",
+            value: "scrape",
+            description: "Scrape a URL and return its content",
+            action: "Scrape a URL",
+          },
+          {
+            name: "Estimate Cost",
+            value: "estimateCost",
+            description:
+              "Estimate the cost of scraping a URL without actually scraping it",
+            action: "Estimate scraping cost",
+          },
+        ],
+        description: "The operation to perform",
+      },
 
-			// ── Output Options ───────────────────────────────────
-			{
-				displayName: 'Output Options',
-				name: 'outputOptions',
-				type: 'collection',
-				placeholder: 'Add Option',
-				default: {},
-				options: [
-					{
-						displayName: 'Formats',
-						name: 'formats',
-						type: 'multiOptions',
-						default: ['markdown', 'json'],
-						options: [
-							{ name: 'Markdown', value: 'markdown' },
-							{ name: 'JSON', value: 'json' },
-							{ name: 'HTML', value: 'html' },
-							{ name: 'Text', value: 'text' },
-						],
-						description: 'Output formats for content transformation',
-					},
-					{
-						displayName: 'Include Raw HTML',
-						name: 'includeRawHtml',
-						type: 'boolean',
-						default: false,
-						description: 'Whether to include the raw HTML in the response',
-					},
-					{
-						displayName: 'Timeout (Seconds)',
-						name: 'timeout',
-						type: 'number',
-						default: 90,
-						typeOptions: { minValue: 1, maxValue: 300 },
-						description: 'Request timeout in seconds (1-300)',
-					},
-				],
-			},
+      // ── Primary ──────────────────────────────────────────
+      {
+        displayName: "URL",
+        name: "url",
+        type: "string",
+        default: "",
+        required: true,
+        placeholder: "https://www.example.com/page",
+        description: "The URL to scrape",
+      },
+      {
+        displayName: "Mode",
+        name: "mode",
+        type: "options",
+        default: "auto",
+        options: [
+          {
+            name: "Auto",
+            value: "auto",
+            description: "Automatically choose the best scraping method",
+          },
+          {
+            name: "HTML",
+            value: "html",
+            description: "Fast HTTP-only scraping for static pages",
+          },
+          {
+            name: "JavaScript",
+            value: "js",
+            description: "Render JavaScript with headless browser",
+          },
+          {
+            name: "PDF",
+            value: "pdf",
+            description: "Extract text from PDF documents",
+          },
+          {
+            name: "OCR",
+            value: "ocr",
+            description: "Extract text from images",
+          },
+        ],
+        description: "Scraping mode to use",
+      },
 
-			// ── Execution Mode ───────────────────────────────────
-			{
-				displayName: 'Execution Mode',
-				name: 'executionMode',
-				type: 'collection',
-				placeholder: 'Add Option',
-				default: {},
-				options: [
-					{
-						displayName: 'Cache',
-						name: 'cache',
-						type: 'boolean',
-						default: false,
-						description: 'Whether to enable response caching',
-					},
-					{
-						displayName: 'Cache TTL (Seconds)',
-						name: 'cacheTtl',
-						type: 'number',
-						default: 900,
-						typeOptions: { minValue: 60, maxValue: 86400 },
-						description: 'Cache time-to-live in seconds (60-86400)',
-						displayOptions: {
-							show: {
-								cache: [true],
-							},
-						},
-					},
-				],
-			},
+      // ── Output Options ───────────────────────────────────
+      {
+        displayName: "Output Options",
+        name: "outputOptions",
+        type: "collection",
+        placeholder: "Add Option",
+        default: {},
+        displayOptions: {
+          show: {
+            operation: ["scrape"],
+          },
+        },
+        options: [
+          {
+            displayName: "Formats",
+            name: "formats",
+            type: "multiOptions",
+            default: ["markdown", "json"],
+            options: [
+              { name: "Markdown", value: "markdown" },
+              { name: "JSON", value: "json" },
+              { name: "HTML", value: "html" },
+              { name: "Text", value: "text" },
+            ],
+            description: "Output formats for content transformation",
+          },
+          {
+            displayName: "Include Raw HTML",
+            name: "includeRawHtml",
+            type: "boolean",
+            default: false,
+            description: "Whether to include the raw HTML in the response",
+          },
+          {
+            displayName: "Timeout (Seconds)",
+            name: "timeout",
+            type: "number",
+            default: 90,
+            typeOptions: { minValue: 1, maxValue: 300 },
+            description: "Request timeout in seconds (1-300)",
+          },
+        ],
+      },
 
-			// ── Advanced Options ─────────────────────────────────
-			{
-				displayName: 'Advanced Options',
-				name: 'advancedOptions',
-				type: 'collection',
-				placeholder: 'Add Option',
-				default: {},
-				options: [
-					{
-						displayName: 'Render JavaScript',
-						name: 'renderJs',
-						type: 'boolean',
-						default: false,
-						description:
-							'Whether to render JavaScript with a headless browser (+$0.0006)',
-					},
-					{
-						displayName: 'Screenshot',
-						name: 'screenshot',
-						type: 'boolean',
-						default: false,
-						description:
-							'Whether to capture a full-page screenshot (+$0.0002, requires Render JavaScript)',
-						displayOptions: {
-							show: {
-								renderJs: [true],
-							},
-						},
-					},
-					{
-						displayName: 'Generate PDF',
-						name: 'generatePdf',
-						type: 'boolean',
-						default: false,
-						description:
-							'Whether to generate a PDF of the rendered page (+$0.0004, requires Render JavaScript)',
-						displayOptions: {
-							show: {
-								renderJs: [true],
-							},
-						},
-					},
-					{
-						displayName: 'OCR',
-						name: 'ocr',
-						type: 'boolean',
-						default: false,
-						description:
-							'Whether to extract text from images using OCR (+$0.001, refunded if no images found)',
-					},
-					{
-						displayName: 'Use Proxy',
-						name: 'useProxy',
-						type: 'boolean',
-						default: false,
-						description: 'Whether to route through a premium proxy (+$0.0002)',
-					},
-					{
-						displayName: 'Proxy Country',
-						name: 'proxyCountry',
-						type: 'string',
-						default: '',
-						placeholder: 'US',
-						description:
-							'Preferred proxy country code for geo-targeting (e.g. US, DE, GB)',
-						displayOptions: {
-							show: {
-								useProxy: [true],
-							},
-						},
-					},
-					{
-						displayName: 'Wait Condition',
-						name: 'waitCondition',
-						type: 'options',
-						default: 'networkidle',
-						options: [
-							{
-								name: 'Network Idle',
-								value: 'networkidle',
-								description: 'Wait until network is idle',
-							},
-							{
-								name: 'DOM Content Loaded',
-								value: 'domcontentloaded',
-								description: 'Wait until DOM content is loaded',
-							},
-							{
-								name: 'Load',
-								value: 'load',
-								description: 'Wait until page load event',
-							},
-						],
-						description: 'When to consider the page ready (JS rendering only)',
-						displayOptions: {
-							show: {
-								renderJs: [true],
-							},
-						},
-					},
-					{
-						displayName: 'Remove Cookie Banners',
-						name: 'removeCookieBanners',
-						type: 'boolean',
-						default: true,
-						description:
-							'Whether to remove cookie consent banners before content extraction',
-					},
-				],
-			},
+      // ── Execution Mode ───────────────────────────────────
+      {
+        displayName: "Execution Mode",
+        name: "executionMode",
+        type: "collection",
+        placeholder: "Add Option",
+        default: {},
+        displayOptions: {
+          show: {
+            operation: ["scrape"],
+          },
+        },
+        options: [
+          {
+            displayName: "Cache",
+            name: "cache",
+            type: "boolean",
+            default: false,
+            description: "Whether to enable response caching",
+          },
+          {
+            displayName: "Cache TTL (Seconds)",
+            name: "cacheTtl",
+            type: "number",
+            default: 900,
+            typeOptions: { minValue: 60, maxValue: 86400 },
+            description: "Cache time-to-live in seconds (60-86400)",
+            displayOptions: {
+              show: {
+                cache: [true],
+              },
+            },
+          },
+        ],
+      },
 
-			// ── Extraction ───────────────────────────────────────
-			{
-				displayName: 'Extraction',
-				name: 'extraction',
-				type: 'collection',
-				placeholder: 'Add Option',
-				default: {},
-				options: [
-					{
-						displayName: 'Extraction Profile',
-						name: 'extractionProfile',
-						type: 'options',
-						default: 'auto',
-						options: [
-							{ name: 'Auto', value: 'auto' },
-							{ name: 'Product', value: 'product' },
-							{ name: 'Article', value: 'article' },
-							{ name: 'Job Posting', value: 'job_posting' },
-							{ name: 'FAQ', value: 'faq' },
-							{ name: 'Recipe', value: 'recipe' },
-							{ name: 'Event', value: 'event' },
-						],
-						description: 'Pre-defined extraction profile for structured data',
-					},
-					{
-						displayName: 'Extraction Prompt',
-						name: 'extractionPrompt',
-						type: 'string',
-						typeOptions: { rows: 4 },
-						default: '',
-						placeholder: 'Extract the product name, price, and rating...',
-						description:
-							'Natural language instructions for what data to extract',
-					},
-					{
-						displayName: 'Extraction Schema (JSON)',
-						name: 'extractionSchema',
-						type: 'json',
-						default: '',
-						placeholder: '{"name": "string", "price": "number"}',
-						description:
-							'JSON Schema to filter and structure extracted data',
-					},
-					{
-						displayName: 'Promote Schema.org',
-						name: 'promoteSchemaOrg',
-						type: 'boolean',
-						default: true,
-						description:
-							'Whether to use Schema.org structured data as primary output when available',
-					},
-					{
-						displayName: 'Evidence',
-						name: 'evidence',
-						type: 'boolean',
-						default: false,
-						description:
-							'Whether to include provenance/evidence for extracted fields',
-					},
-				],
-			},
+      // ── Advanced Options ─────────────────────────────────
+      {
+        displayName: "Advanced Options",
+        name: "advancedOptions",
+        type: "collection",
+        placeholder: "Add Option",
+        default: {},
+        options: [
+          {
+            displayName: "Render JavaScript",
+            name: "renderJs",
+            type: "boolean",
+            default: false,
+            description:
+              "Whether to render JavaScript with a headless browser (+$0.0006)",
+          },
+          {
+            displayName: "Screenshot",
+            name: "screenshot",
+            type: "boolean",
+            default: false,
+            description:
+              "Whether to capture a full-page screenshot (+$0.0002, requires Render JavaScript)",
+            displayOptions: {
+              show: {
+                renderJs: [true],
+              },
+            },
+          },
+          {
+            displayName: "Generate PDF",
+            name: "generatePdf",
+            type: "boolean",
+            default: false,
+            description:
+              "Whether to generate a PDF of the rendered page (+$0.0004, requires Render JavaScript)",
+            displayOptions: {
+              show: {
+                renderJs: [true],
+              },
+            },
+          },
+          {
+            displayName: "OCR",
+            name: "ocr",
+            type: "boolean",
+            default: false,
+            description:
+              "Whether to extract text from images using OCR (+$0.001, refunded if no images found)",
+          },
+          {
+            displayName: "Use Proxy",
+            name: "useProxy",
+            type: "boolean",
+            default: false,
+            description: "Whether to route through a premium proxy (+$0.0002)",
+          },
+          {
+            displayName: "Proxy Country",
+            name: "proxyCountry",
+            type: "string",
+            default: "",
+            placeholder: "US",
+            description:
+              "Preferred proxy country code for geo-targeting (e.g. US, DE, GB)",
+            displayOptions: {
+              show: {
+                useProxy: [true],
+              },
+            },
+          },
+          {
+            displayName: "Wait Condition",
+            name: "waitCondition",
+            type: "options",
+            default: "networkidle",
+            options: [
+              {
+                name: "Network Idle",
+                value: "networkidle",
+                description: "Wait until network is idle",
+              },
+              {
+                name: "DOM Content Loaded",
+                value: "domcontentloaded",
+                description: "Wait until DOM content is loaded",
+              },
+              {
+                name: "Load",
+                value: "load",
+                description: "Wait until page load event",
+              },
+            ],
+            description: "When to consider the page ready (JS rendering only)",
+            displayOptions: {
+              show: {
+                renderJs: [true],
+              },
+            },
+          },
+          {
+            displayName: "Remove Cookie Banners",
+            name: "removeCookieBanners",
+            type: "boolean",
+            default: true,
+            description:
+              "Whether to remove cookie consent banners before content extraction",
+          },
+        ],
+      },
 
-			// ── Cost Controls ────────────────────────────────────
-			{
-				displayName: 'Cost Controls',
-				name: 'costControls',
-				type: 'collection',
-				placeholder: 'Add Option',
-				default: {},
-				options: [
-					{
-						displayName: 'Max Spend',
-						name: 'maxCredits',
-						type: 'number',
-						default: 0,
-						typeOptions: { minValue: 0 },
-						description: 'Maximum to spend per request in microcents (0 = no limit)',
-					},
-					{
-						displayName: 'Force Tier',
-						name: 'forceTier',
-						type: 'options',
-						default: '',
-						options: [
-							{ name: 'None', value: '' },
-							{ name: 'T1 Curl — $0.0002', value: '1' },
-							{ name: 'T2 HTTP — $0.0003', value: '2' },
-							{ name: 'T3 Stealth — $0.0005', value: '3' },
-							{ name: 'T3.5 Light JS — $0.0007', value: '3.5' },
-							{ name: 'T4 Browser — $0.001', value: '4' },
-						],
-						description: 'Force a specific scraping tier (skip escalation)',
-					},
-					{
-						displayName: 'Max Tier',
-						name: 'maxTier',
-						type: 'options',
-						default: '',
-						options: [
-							{ name: 'None', value: '' },
-							{ name: 'T1 Curl — $0.0002', value: '1' },
-							{ name: 'T2 HTTP — $0.0003', value: '2' },
-							{ name: 'T3 Stealth — $0.0005', value: '3' },
-							{ name: 'T3.5 Light JS — $0.0007', value: '3.5' },
-							{ name: 'T4 Browser — $0.001', value: '4' },
-						],
-						description: 'Maximum tier to escalate to',
-					},
-					{
-						displayName: 'Prefer Cost',
-						name: 'preferCost',
-						type: 'boolean',
-						default: false,
-						description: 'Whether to optimize for lower cost (try cheaper tiers first)',
-					},
-					{
-						displayName: 'Prefer Speed',
-						name: 'preferSpeed',
-						type: 'boolean',
-						default: false,
-						description:
-							'Whether to optimize for speed (skip to reliable tier)',
-					},
-					{
-						displayName: 'Fail Fast',
-						name: 'failFast',
-						type: 'boolean',
-						default: false,
-						description:
-							'Whether to return an error instead of escalating to expensive tiers',
-					},
-				],
-			},
-		],
-	};
+      // ── Extraction ───────────────────────────────────────
+      {
+        displayName: "Extraction",
+        name: "extraction",
+        type: "collection",
+        placeholder: "Add Option",
+        default: {},
+        displayOptions: {
+          show: {
+            operation: ["scrape"],
+          },
+        },
+        options: [
+          {
+            displayName: "Extraction Profile",
+            name: "extractionProfile",
+            type: "options",
+            default: "auto",
+            options: [
+              { name: "Auto", value: "auto" },
+              { name: "Product", value: "product" },
+              { name: "Article", value: "article" },
+              { name: "Job Posting", value: "job_posting" },
+              { name: "FAQ", value: "faq" },
+              { name: "Recipe", value: "recipe" },
+              { name: "Event", value: "event" },
+            ],
+            description: "Pre-defined extraction profile for structured data",
+          },
+          {
+            displayName: "Extraction Prompt",
+            name: "extractionPrompt",
+            type: "string",
+            typeOptions: { rows: 4 },
+            default: "",
+            placeholder: "Extract the product name, price, and rating...",
+            description:
+              "Natural language instructions for what data to extract",
+          },
+          {
+            displayName: "Extraction Schema (JSON)",
+            name: "extractionSchema",
+            type: "json",
+            default: "",
+            placeholder: '{"name": "string", "price": "number"}',
+            description: "JSON Schema to filter and structure extracted data",
+          },
+          {
+            displayName: "Promote Schema.org",
+            name: "promoteSchemaOrg",
+            type: "boolean",
+            default: true,
+            description:
+              "Whether to use Schema.org structured data as primary output when available",
+          },
+          {
+            displayName: "Evidence",
+            name: "evidence",
+            type: "boolean",
+            default: false,
+            description:
+              "Whether to include provenance/evidence for extracted fields",
+          },
+        ],
+      },
 
-	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const items = this.getInputData();
-		const results: INodeExecutionData[] = [];
+      // ── Cost Controls ────────────────────────────────────
+      {
+        displayName: "Cost Controls",
+        name: "costControls",
+        type: "collection",
+        placeholder: "Add Option",
+        default: {},
+        options: [
+          {
+            displayName: "Max Spend",
+            name: "maxCredits",
+            type: "number",
+            default: 0,
+            typeOptions: { minValue: 0 },
+            description:
+              "Maximum to spend per request in microcents (0 = no limit)",
+          },
+          {
+            displayName: "Force Tier",
+            name: "forceTier",
+            type: "options",
+            default: "",
+            options: [
+              { name: "None", value: "" },
+              { name: "T1 Curl — $0.0002", value: "1" },
+              { name: "T2 HTTP — $0.0003", value: "2" },
+              { name: "T3 Stealth — $0.0005", value: "3" },
+              { name: "T3.5 Light JS — $0.0007", value: "3.5" },
+              { name: "T4 Browser — $0.001", value: "4" },
+            ],
+            description: "Force a specific scraping tier (skip escalation)",
+          },
+          {
+            displayName: "Max Tier",
+            name: "maxTier",
+            type: "options",
+            default: "",
+            options: [
+              { name: "None", value: "" },
+              { name: "T1 Curl — $0.0002", value: "1" },
+              { name: "T2 HTTP — $0.0003", value: "2" },
+              { name: "T3 Stealth — $0.0005", value: "3" },
+              { name: "T3.5 Light JS — $0.0007", value: "3.5" },
+              { name: "T4 Browser — $0.001", value: "4" },
+            ],
+            description: "Maximum tier to escalate to",
+          },
+          {
+            displayName: "Prefer Cost",
+            name: "preferCost",
+            type: "boolean",
+            default: false,
+            description:
+              "Whether to optimize for lower cost (try cheaper tiers first)",
+          },
+          {
+            displayName: "Prefer Speed",
+            name: "preferSpeed",
+            type: "boolean",
+            default: false,
+            description:
+              "Whether to optimize for speed (skip to reliable tier)",
+          },
+          {
+            displayName: "Fail Fast",
+            name: "failFast",
+            type: "boolean",
+            default: false,
+            description:
+              "Whether to return an error instead of escalating to expensive tiers",
+          },
+        ],
+      },
+    ],
+  };
 
-		for (let i = 0; i < items.length; i++) {
-			try {
-				const url = this.getNodeParameter('url', i) as string;
-				const mode = this.getNodeParameter('mode', i) as string;
-				const outputOptions = this.getNodeParameter('outputOptions', i, {}) as {
-					formats?: string[];
-					includeRawHtml?: boolean;
-					timeout?: number;
-				};
-				const executionMode = this.getNodeParameter('executionMode', i, {}) as {
-					cache?: boolean;
-					cacheTtl?: number;
-				};
-				const advancedOptions = this.getNodeParameter('advancedOptions', i, {}) as {
-					renderJs?: boolean;
-					screenshot?: boolean;
-					generatePdf?: boolean;
-					ocr?: boolean;
-					useProxy?: boolean;
-					proxyCountry?: string;
-					waitCondition?: string;
-					removeCookieBanners?: boolean;
-				};
-				const extraction = this.getNodeParameter('extraction', i, {}) as {
-					extractionProfile?: string;
-					extractionPrompt?: string;
-					extractionSchema?: string;
-					promoteSchemaOrg?: boolean;
-					evidence?: boolean;
-				};
-				const costControls = this.getNodeParameter('costControls', i, {}) as {
-					maxCredits?: number;
-					forceTier?: string;
-					maxTier?: string;
-					preferCost?: boolean;
-					preferSpeed?: boolean;
-					failFast?: boolean;
-				};
+  async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+    const items = this.getInputData();
+    const results: INodeExecutionData[] = [];
 
-				// Build request body
-				const body: Record<string, unknown> = {
-					url,
-					mode,
-					sync: true,
-				};
+    for (let i = 0; i < items.length; i++) {
+      try {
+        const operation = this.getNodeParameter("operation", i) as string;
+        const url = this.getNodeParameter("url", i) as string;
+        const mode = this.getNodeParameter("mode", i) as string;
 
-				// Output options
-				if (outputOptions.formats?.length) {
-					body.formats = outputOptions.formats;
-				}
-				if (outputOptions.includeRawHtml) {
-					body.include_raw_html = true;
-				}
-				if (outputOptions.timeout && outputOptions.timeout !== 90) {
-					body.timeout = outputOptions.timeout;
-				}
+        // ── Estimate Cost operation ───────────────────────
+        if (operation === "estimateCost") {
+          const advancedOptions = this.getNodeParameter(
+            "advancedOptions",
+            i,
+            {},
+          ) as {
+            renderJs?: boolean;
+            useProxy?: boolean;
+            proxyCountry?: string;
+          };
+          const costControls = this.getNodeParameter("costControls", i, {}) as {
+            maxCredits?: number;
+            forceTier?: string;
+            maxTier?: string;
+            preferCost?: boolean;
+            preferSpeed?: boolean;
+            failFast?: boolean;
+          };
 
-				// Execution mode
-				if (executionMode.cache) {
-					body.cache = true;
-					if (executionMode.cacheTtl && executionMode.cacheTtl !== 900) {
-						body.cache_ttl = executionMode.cacheTtl;
-					}
-				}
+          const body: Record<string, unknown> = { url, mode };
 
-				// Advanced options → nested "advanced" object
-				const advanced: Record<string, unknown> = {};
-				if (advancedOptions.renderJs) advanced.render_js = true;
-				if (advancedOptions.screenshot) advanced.screenshot = true;
-				if (advancedOptions.generatePdf) advanced.generate_pdf = true;
-				if (advancedOptions.ocr) advanced.ocr = true;
-				if (advancedOptions.useProxy) advanced.use_proxy = true;
-				if (advancedOptions.proxyCountry) {
-					advanced.proxy_country = advancedOptions.proxyCountry;
-				}
-				if (advancedOptions.waitCondition && advancedOptions.waitCondition !== 'networkidle') {
-					advanced.wait_condition = advancedOptions.waitCondition;
-				}
-				if (advancedOptions.removeCookieBanners === false) {
-					advanced.remove_cookie_banners = false;
-				}
-				if (Object.keys(advanced).length > 0) {
-					body.advanced = advanced;
-				}
+          const advanced: Record<string, unknown> = {};
+          if (advancedOptions.renderJs) advanced.render_js = true;
+          if (advancedOptions.useProxy) advanced.use_proxy = true;
+          if (advancedOptions.proxyCountry) {
+            advanced.proxy_country = advancedOptions.proxyCountry;
+          }
+          if (Object.keys(advanced).length > 0) {
+            body.advanced = advanced;
+          }
 
-				// Extraction
-				if (extraction.extractionProfile && extraction.extractionProfile !== 'auto') {
-					body.extraction_profile = extraction.extractionProfile;
-				}
-				if (extraction.extractionPrompt) {
-					body.extraction_prompt = extraction.extractionPrompt;
-				}
-				if (extraction.extractionSchema) {
-					try {
-						body.extraction_schema =
-							typeof extraction.extractionSchema === 'string'
-								? JSON.parse(extraction.extractionSchema)
-								: extraction.extractionSchema;
-					} catch {
-						throw new NodeOperationError(
-							this.getNode(),
-							'Invalid JSON in Extraction Schema',
-							{ itemIndex: i },
-						);
-					}
-				}
-				if (extraction.promoteSchemaOrg === false) {
-					body.promote_schema_org = false;
-				}
-				if (extraction.evidence) {
-					body.evidence = true;
-				}
+          const costCtrl: Record<string, unknown> = {};
+          if (costControls.maxCredits && costControls.maxCredits > 0) {
+            costCtrl.max_credits = costControls.maxCredits;
+          }
+          if (costControls.forceTier)
+            costCtrl.force_tier = costControls.forceTier;
+          if (costControls.maxTier) costCtrl.max_tier = costControls.maxTier;
+          if (costControls.preferCost) costCtrl.prefer_cost = true;
+          if (costControls.preferSpeed) costCtrl.prefer_speed = true;
+          if (costControls.failFast) costCtrl.fail_fast = true;
+          if (Object.keys(costCtrl).length > 0) {
+            body.cost_controls = costCtrl;
+          }
 
-				// Cost controls → nested "cost_controls" object
-				const costCtrl: Record<string, unknown> = {};
-				if (costControls.maxCredits && costControls.maxCredits > 0) {
-					costCtrl.max_credits = costControls.maxCredits;
-				}
-				if (costControls.forceTier) {
-					costCtrl.force_tier = costControls.forceTier;
-				}
-				if (costControls.maxTier) {
-					costCtrl.max_tier = costControls.maxTier;
-				}
-				if (costControls.preferCost) costCtrl.prefer_cost = true;
-				if (costControls.preferSpeed) costCtrl.prefer_speed = true;
-				if (costControls.failFast) costCtrl.fail_fast = true;
-				if (Object.keys(costCtrl).length > 0) {
-					body.cost_controls = costCtrl;
-				}
+          let authName = "alterLabApi";
+          try {
+            await this.getCredentials("alterLabOAuth2Api");
+            authName = "alterLabOAuth2Api";
+          } catch {
+            // OAuth2 not configured, fall back to API key
+          }
 
-				// ── Detect credential type ────────────────────────
-				let authName = 'alterLabApi';
-				try {
-					await this.getCredentials('alterLabOAuth2Api');
-					authName = 'alterLabOAuth2Api';
-				} catch {
-					// OAuth2 not configured, fall back to API key
-				}
+          const response =
+            await this.helpers.httpRequestWithAuthentication.call(
+              this,
+              authName,
+              {
+                method: "POST",
+                url: "/api/v1/scrape/estimate",
+                body,
+                json: true,
+                returnFullResponse: true,
+                ignoreHttpStatusErrors: true,
+              },
+            );
 
-				// ── Make the API call ─────────────────────────────
-				let response = await this.helpers.httpRequestWithAuthentication.call(
-					this,
-					authName,
-					{
-						method: 'POST',
-						url: '/api/v1/scrape',
-						body,
-						json: true,
-						returnFullResponse: true,
-						ignoreHttpStatusErrors: true,
-					},
-				);
+          const statusCode = (response as { statusCode: number }).statusCode;
+          const responseBody = (response as { body: Record<string, unknown> })
+            .body;
 
-				let statusCode = (response as { statusCode: number }).statusCode;
-				let responseBody = (response as { body: Record<string, unknown> }).body;
+          if (statusCode >= 400) {
+            handleApiError(this, statusCode, responseBody as JsonObject, i);
+          }
 
-				// ── Handle async (202) with polling ───────────────
-				if (statusCode === 202 && responseBody?.job_id) {
-					const jobId = responseBody.job_id as string;
-					let delay = 500;
-					const maxDelay = 5000;
-					const maxPollTime = ((outputOptions.timeout ?? 90) + 30) * 1000; // timeout + 30s buffer
-					const pollStart = Date.now();
+          const data = responseBody as Record<string, unknown>;
+          results.push({
+            json: {
+              url: (data.url as string) ?? "",
+              estimatedTier: (data.estimated_tier as string) ?? "unknown",
+              estimatedCredits: (data.estimated_credits as number) ?? 0,
+              confidence: (data.confidence as string) ?? "low",
+              maxPossibleCredits: (data.max_possible_credits as number) ?? 0,
+              reasoning: (data.reasoning as string) ?? "",
+            },
+          });
+          continue;
+        }
 
-					while (Date.now() - pollStart < maxPollTime) {
-						await new Promise<void>((resolve) => setTimeout(resolve, delay));
-						delay = Math.min(delay * 2, maxDelay);
+        // ── Scrape operation ──────────────────────────────
+        const outputOptions = this.getNodeParameter("outputOptions", i, {}) as {
+          formats?: string[];
+          includeRawHtml?: boolean;
+          timeout?: number;
+        };
+        const executionMode = this.getNodeParameter("executionMode", i, {}) as {
+          cache?: boolean;
+          cacheTtl?: number;
+        };
+        const advancedOptions = this.getNodeParameter(
+          "advancedOptions",
+          i,
+          {},
+        ) as {
+          renderJs?: boolean;
+          screenshot?: boolean;
+          generatePdf?: boolean;
+          ocr?: boolean;
+          useProxy?: boolean;
+          proxyCountry?: string;
+          waitCondition?: string;
+          removeCookieBanners?: boolean;
+        };
+        const extraction = this.getNodeParameter("extraction", i, {}) as {
+          extractionProfile?: string;
+          extractionPrompt?: string;
+          extractionSchema?: string;
+          promoteSchemaOrg?: boolean;
+          evidence?: boolean;
+        };
+        const costControls = this.getNodeParameter("costControls", i, {}) as {
+          maxCredits?: number;
+          forceTier?: string;
+          maxTier?: string;
+          preferCost?: boolean;
+          preferSpeed?: boolean;
+          failFast?: boolean;
+        };
 
-						const pollResponse = await this.helpers.httpRequestWithAuthentication.call(
-							this,
-							authName,
-							{
-								method: 'GET',
-								url: `/api/v1/jobs/${jobId}`,
-								json: true,
-								returnFullResponse: true,
-								ignoreHttpStatusErrors: true,
-							},
-						);
+        // Build request body
+        const body: Record<string, unknown> = {
+          url,
+          mode,
+          sync: true,
+        };
 
-						const pollStatus = (pollResponse as { statusCode: number }).statusCode;
-						const pollBody = (pollResponse as { body: Record<string, unknown> }).body;
+        // Output options
+        if (outputOptions.formats?.length) {
+          body.formats = outputOptions.formats;
+        }
+        if (outputOptions.includeRawHtml) {
+          body.include_raw_html = true;
+        }
+        if (outputOptions.timeout && outputOptions.timeout !== 90) {
+          body.timeout = outputOptions.timeout;
+        }
 
-						if (pollStatus === 200 && pollBody?.status_code) {
-							statusCode = 200;
-							responseBody = pollBody;
-							break;
-						}
+        // Execution mode
+        if (executionMode.cache) {
+          body.cache = true;
+          if (executionMode.cacheTtl && executionMode.cacheTtl !== 900) {
+            body.cache_ttl = executionMode.cacheTtl;
+          }
+        }
 
-						if (pollStatus >= 400) {
-							statusCode = pollStatus;
-							responseBody = pollBody;
-							break;
-						}
+        // Advanced options → nested "advanced" object
+        const advanced: Record<string, unknown> = {};
+        if (advancedOptions.renderJs) advanced.render_js = true;
+        if (advancedOptions.screenshot) advanced.screenshot = true;
+        if (advancedOptions.generatePdf) advanced.generate_pdf = true;
+        if (advancedOptions.ocr) advanced.ocr = true;
+        if (advancedOptions.useProxy) advanced.use_proxy = true;
+        if (advancedOptions.proxyCountry) {
+          advanced.proxy_country = advancedOptions.proxyCountry;
+        }
+        if (
+          advancedOptions.waitCondition &&
+          advancedOptions.waitCondition !== "networkidle"
+        ) {
+          advanced.wait_condition = advancedOptions.waitCondition;
+        }
+        if (advancedOptions.removeCookieBanners === false) {
+          advanced.remove_cookie_banners = false;
+        }
+        if (Object.keys(advanced).length > 0) {
+          body.advanced = advanced;
+        }
 
-						// Still processing (200 with status: "processing") — continue polling
-					}
+        // Extraction
+        if (
+          extraction.extractionProfile &&
+          extraction.extractionProfile !== "auto"
+        ) {
+          body.extraction_profile = extraction.extractionProfile;
+        }
+        if (extraction.extractionPrompt) {
+          body.extraction_prompt = extraction.extractionPrompt;
+        }
+        if (extraction.extractionSchema) {
+          try {
+            body.extraction_schema =
+              typeof extraction.extractionSchema === "string"
+                ? JSON.parse(extraction.extractionSchema)
+                : extraction.extractionSchema;
+          } catch {
+            throw new NodeOperationError(
+              this.getNode(),
+              "Invalid JSON in Extraction Schema",
+              { itemIndex: i },
+            );
+          }
+        }
+        if (extraction.promoteSchemaOrg === false) {
+          body.promote_schema_org = false;
+        }
+        if (extraction.evidence) {
+          body.evidence = true;
+        }
 
-					if (statusCode === 202) {
-						throw new NodeOperationError(
-							this.getNode(),
-							'Scrape job timed out while waiting for results. Try increasing the timeout or using a simpler scraping mode.',
-							{ itemIndex: i },
-						);
-					}
-				}
+        // Cost controls → nested "cost_controls" object
+        const costCtrl: Record<string, unknown> = {};
+        if (costControls.maxCredits && costControls.maxCredits > 0) {
+          costCtrl.max_credits = costControls.maxCredits;
+        }
+        if (costControls.forceTier) {
+          costCtrl.force_tier = costControls.forceTier;
+        }
+        if (costControls.maxTier) {
+          costCtrl.max_tier = costControls.maxTier;
+        }
+        if (costControls.preferCost) costCtrl.prefer_cost = true;
+        if (costControls.preferSpeed) costCtrl.prefer_speed = true;
+        if (costControls.failFast) costCtrl.fail_fast = true;
+        if (Object.keys(costCtrl).length > 0) {
+          body.cost_controls = costCtrl;
+        }
 
-				// ── Handle errors ─────────────────────────────────
-				if (statusCode >= 400) {
-					handleApiError(this, statusCode, responseBody as JsonObject, i);
-				}
+        // ── Detect credential type ────────────────────────
+        let authName = "alterLabApi";
+        try {
+          await this.getCredentials("alterLabOAuth2Api");
+          authName = "alterLabOAuth2Api";
+        } catch {
+          // OAuth2 not configured, fall back to API key
+        }
 
-				// ── Format output ─────────────────────────────────
-				const data = responseBody as Record<string, unknown>;
-				const content = data.content as Record<string, unknown> | string | undefined;
+        // ── Make the API call ─────────────────────────────
+        let response = await this.helpers.httpRequestWithAuthentication.call(
+          this,
+          authName,
+          {
+            method: "POST",
+            url: "/api/v1/scrape",
+            body,
+            json: true,
+            returnFullResponse: true,
+            ignoreHttpStatusErrors: true,
+          },
+        );
 
-				const output: IDataObject = {
-					url: (data.url as string) ?? '',
-					statusCode: (data.status_code as number) ?? 0,
-					title: (data.title as string) ?? null,
-					author: (data.author as string) ?? null,
-					publishedAt: (data.published_at as string) ?? null,
-					cached: (data.cached as boolean) ?? false,
-					responseTimeMs: (data.response_time_ms as number) ?? 0,
-					sizeBytes: (data.size_bytes as number) ?? 0,
-				};
+        let statusCode = (response as { statusCode: number }).statusCode;
+        let responseBody = (response as { body: Record<string, unknown> }).body;
 
-				// Flatten multi-format content
-				if (content && typeof content === 'object') {
-					output.markdown = (content as Record<string, unknown>).markdown ?? null;
-					output.text = (content as Record<string, unknown>).text ?? null;
-					output.json = (content as Record<string, unknown>).json ?? null;
-					output.html = (content as Record<string, unknown>).html ?? null;
-				} else {
-					output.markdown = content ?? null;
-				}
+        // ── Handle async (202) with polling ───────────────
+        if (statusCode === 202 && responseBody?.job_id) {
+          const jobId = responseBody.job_id as string;
+          let delay = 500;
+          const maxDelay = 5000;
+          const maxPollTime = ((outputOptions.timeout ?? 90) + 30) * 1000; // timeout + 30s buffer
+          const pollStart = Date.now();
 
-				// Extraction results
-				output.filteredContent = data.filtered_content ?? null;
-				output.extractionMethod = data.extraction_method ?? null;
+          while (Date.now() - pollStart < maxPollTime) {
+            await new Promise<void>((resolve) => setTimeout(resolve, delay));
+            delay = Math.min(delay * 2, maxDelay);
 
-				// Advanced outputs
-				output.screenshotUrl = data.screenshot_url ?? null;
-				output.pdfUrl = data.pdf_url ?? null;
-				output.ocrResults = data.ocr_results ?? null;
-				output.rawHtml = data.raw_html ?? null;
+            const pollResponse =
+              await this.helpers.httpRequestWithAuthentication.call(
+                this,
+                authName,
+                {
+                  method: "GET",
+                  url: `/api/v1/jobs/${jobId}`,
+                  json: true,
+                  returnFullResponse: true,
+                  ignoreHttpStatusErrors: true,
+                },
+              );
 
-				// Billing breakdown (flattened)
-				const billing = data.billing as Record<string, unknown> | undefined;
-				output.billing = {
-					cost: billing?.total_credits ?? data.credits_used ?? 0,
-					tier: billing?.tier_used ?? data.tier_used ?? 'unknown',
-					savings: billing?.savings ?? 0,
-					suggestion: billing?.optimization_suggestion ?? null,
-				};
+            const pollStatus = (pollResponse as { statusCode: number })
+              .statusCode;
+            const pollBody = (pollResponse as { body: Record<string, unknown> })
+              .body;
 
-				results.push({ json: output });
-			} catch (error) {
-				if (this.continueOnFail()) {
-					results.push({
-						json: { error: (error as Error).message },
-						pairedItem: { item: i },
-					});
-					continue;
-				}
-				throw error;
-			}
-		}
+            if (pollStatus === 200 && pollBody?.status_code) {
+              statusCode = 200;
+              responseBody = pollBody;
+              break;
+            }
 
-		return [results];
-	}
+            if (pollStatus >= 400) {
+              statusCode = pollStatus;
+              responseBody = pollBody;
+              break;
+            }
+
+            // Still processing (200 with status: "processing") — continue polling
+          }
+
+          if (statusCode === 202) {
+            throw new NodeOperationError(
+              this.getNode(),
+              "Scrape job timed out while waiting for results. Try increasing the timeout or using a simpler scraping mode.",
+              { itemIndex: i },
+            );
+          }
+        }
+
+        // ── Handle errors ─────────────────────────────────
+        if (statusCode >= 400) {
+          handleApiError(this, statusCode, responseBody as JsonObject, i);
+        }
+
+        // ── Format output ─────────────────────────────────
+        const data = responseBody as Record<string, unknown>;
+        const content = data.content as
+          | Record<string, unknown>
+          | string
+          | undefined;
+
+        const output: IDataObject = {
+          url: (data.url as string) ?? "",
+          statusCode: (data.status_code as number) ?? 0,
+          title: (data.title as string) ?? null,
+          author: (data.author as string) ?? null,
+          publishedAt: (data.published_at as string) ?? null,
+          cached: (data.cached as boolean) ?? false,
+          responseTimeMs: (data.response_time_ms as number) ?? 0,
+          sizeBytes: (data.size_bytes as number) ?? 0,
+        };
+
+        // Flatten multi-format content
+        if (content && typeof content === "object") {
+          output.markdown =
+            (content as Record<string, unknown>).markdown ?? null;
+          output.text = (content as Record<string, unknown>).text ?? null;
+          output.json = (content as Record<string, unknown>).json ?? null;
+          output.html = (content as Record<string, unknown>).html ?? null;
+        } else {
+          output.markdown = content ?? null;
+        }
+
+        // Extraction results
+        output.filteredContent = data.filtered_content ?? null;
+        output.extractionMethod = data.extraction_method ?? null;
+
+        // Advanced outputs
+        output.screenshotUrl = data.screenshot_url ?? null;
+        output.pdfUrl = data.pdf_url ?? null;
+        output.ocrResults = data.ocr_results ?? null;
+        output.rawHtml = data.raw_html ?? null;
+
+        // Billing breakdown (flattened)
+        const billing = data.billing as Record<string, unknown> | undefined;
+        output.billing = {
+          cost: billing?.total_credits ?? data.credits_used ?? 0,
+          tier: billing?.tier_used ?? data.tier_used ?? "unknown",
+          savings: billing?.savings ?? 0,
+          suggestion: billing?.optimization_suggestion ?? null,
+        };
+
+        results.push({ json: output });
+      } catch (error) {
+        if (this.continueOnFail()) {
+          results.push({
+            json: { error: (error as Error).message },
+            pairedItem: { item: i },
+          });
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    return [results];
+  }
 }
 
 function handleApiError(
-	ctx: IExecuteFunctions,
-	statusCode: number,
-	body: JsonObject,
-	itemIndex: number,
+  ctx: IExecuteFunctions,
+  statusCode: number,
+  body: JsonObject,
+  itemIndex: number,
 ): never {
-	const detail = (body?.detail as string) ?? (body?.message as string) ?? 'Unknown error';
+  const detail =
+    (body?.detail as string) ?? (body?.message as string) ?? "Unknown error";
 
-	switch (statusCode) {
-		case 401:
-			throw new NodeApiError(ctx.getNode(), body, {
-				message: 'Invalid API key',
-				description: `${detail}. Check your API key or get a new one at https://app.alterlab.io/dashboard/keys?${UTM}`,
-				httpCode: '401',
-				itemIndex,
-			});
+  switch (statusCode) {
+    case 401:
+      throw new NodeApiError(ctx.getNode(), body, {
+        message: "Invalid API key",
+        description: `${detail}. Check your API key or get a new one at https://app.alterlab.io/dashboard/keys?${UTM}`,
+        httpCode: "401",
+        itemIndex,
+      });
 
-		case 402:
-			throw new NodeApiError(ctx.getNode(), body, {
-				message: 'Insufficient balance',
-				description: `${detail}. Top up your balance at https://app.alterlab.io/dashboard/billing?${UTM}`,
-				httpCode: '402',
-				itemIndex,
-			});
+    case 402:
+      throw new NodeApiError(ctx.getNode(), body, {
+        message: "Insufficient balance",
+        description: `${detail}. Top up your balance at https://app.alterlab.io/dashboard/billing?${UTM}`,
+        httpCode: "402",
+        itemIndex,
+      });
 
-		case 429:
-			throw new NodeApiError(ctx.getNode(), body, {
-				message: 'Rate limit exceeded',
-				description: `${detail}. Upgrade your plan for higher rate limits at https://alterlab.io/pricing?${UTM}`,
-				httpCode: '429',
-				itemIndex,
-			});
+    case 429:
+      throw new NodeApiError(ctx.getNode(), body, {
+        message: "Rate limit exceeded",
+        description: `${detail}. Upgrade your plan for higher rate limits at https://alterlab.io/pricing?${UTM}`,
+        httpCode: "429",
+        itemIndex,
+      });
 
-		case 403:
-			throw new NodeApiError(ctx.getNode(), body, {
-				message: 'Blocked by anti-bot protection',
-				description: `${detail}. Try enabling "Use Proxy" in Advanced Options, or use a higher tier via Cost Controls.`,
-				httpCode: '403',
-				itemIndex,
-			});
+    case 403:
+      throw new NodeApiError(ctx.getNode(), body, {
+        message: "Blocked by anti-bot protection",
+        description: `${detail}. Try enabling "Use Proxy" in Advanced Options, or use a higher tier via Cost Controls.`,
+        httpCode: "403",
+        itemIndex,
+      });
 
-		case 504:
-			throw new NodeApiError(ctx.getNode(), body, {
-				message: 'Request timed out',
-				description: `${detail}. Try increasing the timeout, using async mode, or a simpler scraping mode.`,
-				httpCode: '504',
-				itemIndex,
-			});
+    case 504:
+      throw new NodeApiError(ctx.getNode(), body, {
+        message: "Request timed out",
+        description: `${detail}. Try increasing the timeout, using async mode, or a simpler scraping mode.`,
+        httpCode: "504",
+        itemIndex,
+      });
 
-		default:
-			throw new NodeApiError(ctx.getNode(), body, {
-				message: `API error (${statusCode})`,
-				description: detail,
-				httpCode: String(statusCode),
-				itemIndex,
-			});
-	}
+    default:
+      throw new NodeApiError(ctx.getNode(), body, {
+        message: `API error (${statusCode})`,
+        description: detail,
+        httpCode: String(statusCode),
+        itemIndex,
+      });
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,63 +1,62 @@
 {
-	"name": "n8n-nodes-alterlab",
-	"version": "0.2.2",
-	"description": "n8n community node for AlterLab web scraping API — anti-bot bypass, JS rendering, structured extraction, OCR, and more.",
-	"keywords": [
-		"n8n-community-node-package",
-		"n8n",
-		"web scraping",
-		"scrape",
-		"crawl",
-		"extract",
-		"anti-bot",
-		"proxy",
-		"screenshot",
-		"pdf",
-		"ocr",
-		"alterlab",
-		"data extraction",
-		"headless browser"
-	],
-	"license": "MIT",
-	"homepage": "https://alterlab.io?utm_source=n8n&utm_medium=integration&utm_campaign=community_node",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/RapierCraft/n8n-nodes-alterlab.git"
-	},
-	"author": {
-		"name": "AlterLab",
-		"email": "support@alterlab.io",
-		"url": "https://alterlab.io"
-	},
-	"main": "dist/nodes/AlterLab/AlterLab.node.js",
-	"scripts": {
-		"build": "tsc && gulp build:icons",
-		"dev": "tsc --watch",
-		"lint": "tsc --noEmit",
-		"prepublishOnly": "npm run build"
-	},
-	"files": [
-		"dist"
-	],
-	"n8n": {
-		"n8nNodesApiVersion": 1,
-		"credentials": [
-			"dist/credentials/AlterLabApi.credentials.js",
-			"dist/credentials/AlterLabOAuth2Api.credentials.js"
-		],
-		"nodes": [
-			"dist/nodes/AlterLab/AlterLab.node.js"
-		]
-	},
-	"devDependencies": {
-		"@types/node": "^20.11.0",
-		"gulp": "^4.0.2",
-		"n8n-workflow": "^1.27.0",
-		"typescript": "~5.3.0"
-	},
-	"peerDependencies": {
-		"n8n-workflow": "*"
-	},
-	"dependencies": {}
-
+  "name": "n8n-nodes-alterlab",
+  "version": "0.3.0",
+  "description": "n8n community node for AlterLab web scraping API — anti-bot bypass, JS rendering, structured extraction, OCR, and more.",
+  "keywords": [
+    "n8n-community-node-package",
+    "n8n",
+    "web scraping",
+    "scrape",
+    "crawl",
+    "extract",
+    "anti-bot",
+    "proxy",
+    "screenshot",
+    "pdf",
+    "ocr",
+    "alterlab",
+    "data extraction",
+    "headless browser"
+  ],
+  "license": "MIT",
+  "homepage": "https://alterlab.io?utm_source=n8n&utm_medium=integration&utm_campaign=community_node",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RapierCraft/n8n-nodes-alterlab.git"
+  },
+  "author": {
+    "name": "AlterLab",
+    "email": "support@alterlab.io",
+    "url": "https://alterlab.io"
+  },
+  "main": "dist/nodes/AlterLab/AlterLab.node.js",
+  "scripts": {
+    "build": "tsc && gulp build:icons",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "n8n": {
+    "n8nNodesApiVersion": 1,
+    "credentials": [
+      "dist/credentials/AlterLabApi.credentials.js",
+      "dist/credentials/AlterLabOAuth2Api.credentials.js"
+    ],
+    "nodes": [
+      "dist/nodes/AlterLab/AlterLab.node.js"
+    ]
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "gulp": "^4.0.2",
+    "n8n-workflow": "^1.27.0",
+    "typescript": "~5.3.0"
+  },
+  "peerDependencies": {
+    "n8n-workflow": "*"
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
## Summary
- Add "Estimate Cost" operation to the AlterLab n8n node
- Calls `POST /api/v1/scrape/estimate` returning tier, credits, confidence, and reasoning
- Scrape-only sections (Output Options, Execution Mode, Extraction) hidden when estimate selected
- Version bump 0.2.2 → 0.3.0

Closes RapierCraft/AlterLab#1031

## Changes
- `nodes/AlterLab/AlterLab.node.ts` — Operation dropdown, estimate execution branch, displayOptions
- `nodes/AlterLab/AlterLab.node.json` — Added estimate/pricing aliases
- `package.json` — Version bump