### PR TITLE
Fix: update render_js description — forces T4 minimum, no add-on charge

### DIFF
--- a/nodes/AlterLab/AlterLab.node.ts
+++ b/nodes/AlterLab/AlterLab.node.ts
@@ -250,7 +250,7 @@ export class AlterLab implements INodeType {
             type: "boolean",
             default: false,
             description:
-              "Whether to render JavaScript with a headless browser (+$0.0006)",
+              "Whether to render JavaScript with a headless browser (forces Tier 4 minimum — no separate add-on charge)",
           },
           {
             displayName: "Screenshot",


### PR DESCRIPTION
## Summary

- Removes stale `+$0.0006` flat charge language from the `Render JavaScript` option description
- Updates description to accurately reflect that `render_js` forces Tier 4 minimum pricing with no separate add-on surcharge
- Syncs n8n node documentation with AlterLab platform pricing refactor (PR #5945)

Closes #76

## Changes

- `nodes/AlterLab/AlterLab.node.ts` line 253: description string updated