### PR TITLE
Fix: sync cache_ttl default from 900 to 3600

### DIFF
--- a/nodes/AlterLab/AlterLab.node.ts
+++ b/nodes/AlterLab/AlterLab.node.ts
@@ -219,7 +219,7 @@ export class AlterLab implements INodeType {
             displayName: "Cache TTL (Seconds)",
             name: "cacheTtl",
             type: "number",
-            default: 900,
+            default: 3600,
             typeOptions: { minValue: 60, maxValue: 86400 },
             description: "Cache time-to-live in seconds (60-86400)",
             displayOptions: {
@@ -1362,7 +1362,7 @@ export class AlterLab implements INodeType {
         // Execution mode
         if (executionMode.cache) {
           body.cache = true;
-          if (executionMode.cacheTtl && executionMode.cacheTtl !== 900) {
+          if (executionMode.cacheTtl && executionMode.cacheTtl !== 3600) {
             body.cache_ttl = executionMode.cacheTtl;
           }
         }


### PR DESCRIPTION
## Summary
- Updates `cacheTtl` field default from `900` to `3600` in `AlterLab.node.ts`
- Updates the guard condition from `!== 900` to `!== 3600` so the node omits `cache_ttl` from the request payload when using the default value

Closes #77

## Changes
- `nodes/AlterLab/AlterLab.node.ts` (line 222): `default: 900` → `default: 3600`
- `nodes/AlterLab/AlterLab.node.ts` (line 1365): `cacheTtl !== 900` → `cacheTtl !== 3600`

## Why the Guard Matters
Without this change, the node always sends `cache_ttl: 900` in the request body whenever a user enables caching without explicitly changing TTL. This overrides the API's new 3600s default, defeating the sync.