### PR TITLE
Feat: Full API parity — crawl, search, map, extract, batch

### DIFF
--- a/credentials/AlterLabApi.credentials.ts
+++ b/credentials/AlterLabApi.credentials.ts
@@ -1,50 +1,51 @@
 import type {
-	IAuthenticateGeneric,
-	ICredentialTestRequest,
-	ICredentialType,
-	INodeProperties,
-} from 'n8n-workflow';
+  IAuthenticateGeneric,
+  ICredentialTestRequest,
+  ICredentialType,
+  INodeProperties,
+} from "n8n-workflow";
 
 export class AlterLabApi implements ICredentialType {
-	name = 'alterLabApi';
-	displayName = 'AlterLab API';
-	documentationUrl =
-		'https://docs.alterlab.io/api?utm_source=n8n&utm_medium=integration&utm_campaign=community_node';
+  name = "alterLabApi";
+  displayName = "AlterLab API";
+  documentationUrl =
+    "https://docs.alterlab.io/api?utm_source=n8n&utm_medium=integration&utm_campaign=community_node";
 
-	properties: INodeProperties[] = [
-		{
-			displayName: 'API Key',
-			name: 'apiKey',
-			type: 'string',
-			typeOptions: { password: true },
-			default: '',
-			required: true,
-			description:
-				'Your AlterLab API key. <a href="https://app.alterlab.io/dashboard/keys?utm_source=n8n&utm_medium=integration&utm_campaign=community_node" target="_blank">Find your API key</a> or <a href="https://app.alterlab.io/signin?redirect=/dashboard/keys&source=n8n&utm_source=n8n&utm_medium=integration&utm_campaign=community_node" target="_blank">sign up free — $1 balance, up to 5,000 scrapes</a>.',
-		},
-		{
-			displayName: 'Base URL',
-			name: 'baseUrl',
-			type: 'string',
-			default: 'https://api.alterlab.io',
-			description: 'AlterLab API base URL. Only change for self-hosted instances.',
-		},
-	];
+  properties: INodeProperties[] = [
+    {
+      displayName: "API Key",
+      name: "apiKey",
+      type: "string",
+      typeOptions: { password: true },
+      default: "",
+      required: true,
+      description:
+        'Your AlterLab API key. <a href="https://app.alterlab.io/dashboard/keys?utm_source=n8n&utm_medium=integration&utm_campaign=community_node" target="_blank">Find your API key</a> or <a href="https://app.alterlab.io/signin?redirect=/dashboard/keys&source=n8n&utm_source=n8n&utm_medium=integration&utm_campaign=community_node" target="_blank">sign up free — $1 balance, up to 5,000 scrapes</a>.',
+    },
+    {
+      displayName: "Base URL",
+      name: "baseUrl",
+      type: "string",
+      default: "https://api.alterlab.io",
+      description:
+        "AlterLab API base URL. Only change for self-hosted instances.",
+    },
+  ];
 
-	authenticate: IAuthenticateGeneric = {
-		type: 'generic',
-		properties: {
-			headers: {
-				'X-API-Key': '={{$credentials.apiKey}}',
-			},
-		},
-	};
+  authenticate: IAuthenticateGeneric = {
+    type: "generic",
+    properties: {
+      headers: {
+        "X-API-Key": "={{$credentials.apiKey}}",
+      },
+    },
+  };
 
-	test: ICredentialTestRequest = {
-		request: {
-			baseURL: '={{$credentials.baseUrl}}',
-			url: '/api/v1/usage',
-			method: 'GET',
-		},
-	};
+  test: ICredentialTestRequest = {
+    request: {
+      baseURL: "={{$credentials.baseUrl}}",
+      url: "/api/v1/usage",
+      method: "GET",
+    },
+  };
 }

--- a/credentials/AlterLabOAuth2Api.credentials.ts
+++ b/credentials/AlterLabOAuth2Api.credentials.ts
@@ -1,73 +1,73 @@
 import type {
-	ICredentialTestRequest,
-	ICredentialType,
-	INodeProperties,
-} from 'n8n-workflow';
+  ICredentialTestRequest,
+  ICredentialType,
+  INodeProperties,
+} from "n8n-workflow";
 
 export class AlterLabOAuth2Api implements ICredentialType {
-	name = 'alterLabOAuth2Api';
-	displayName = 'AlterLab OAuth2 API';
-	documentationUrl =
-		'https://docs.alterlab.io/api?utm_source=n8n&utm_medium=integration&utm_campaign=community_node';
+  name = "alterLabOAuth2Api";
+  displayName = "AlterLab OAuth2 API";
+  documentationUrl =
+    "https://docs.alterlab.io/api?utm_source=n8n&utm_medium=integration&utm_campaign=community_node";
 
-	extends = ['oAuth2Api'];
+  extends = ["oAuth2Api"];
 
-	properties: INodeProperties[] = [
-		{
-			displayName: 'Grant Type',
-			name: 'grantType',
-			type: 'hidden',
-			default: 'authorizationCode',
-		},
-		{
-			displayName: 'Authorization URL',
-			name: 'authorizationUrl',
-			type: 'hidden',
-			default: 'https://app.alterlab.io/oauth/authorize',
-		},
-		{
-			displayName: 'Access Token URL',
-			name: 'accessTokenUrl',
-			type: 'hidden',
-			default: 'https://api.alterlab.io/api/v1/oauth/token',
-		},
-		{
-			displayName: 'Client ID',
-			name: 'clientId',
-			type: 'hidden',
-			default: 'n8n-community-node',
-		},
-		{
-			displayName: 'Client Secret',
-			name: 'clientSecret',
-			type: 'hidden',
-			default: 'altrlab_n8n_Kx7mP2vQ9wR4jH6nB3cT5zY8',
-		},
-		{
-			displayName: 'Scope',
-			name: 'scope',
-			type: 'hidden',
-			default: 'scrape',
-		},
-		{
-			displayName: 'Auth URI Query Parameters',
-			name: 'authQueryParameters',
-			type: 'hidden',
-			default: '',
-		},
-		{
-			displayName: 'Authentication',
-			name: 'authentication',
-			type: 'hidden',
-			default: 'body',
-		},
-	];
+  properties: INodeProperties[] = [
+    {
+      displayName: "Grant Type",
+      name: "grantType",
+      type: "hidden",
+      default: "authorizationCode",
+    },
+    {
+      displayName: "Authorization URL",
+      name: "authorizationUrl",
+      type: "hidden",
+      default: "https://app.alterlab.io/oauth/authorize",
+    },
+    {
+      displayName: "Access Token URL",
+      name: "accessTokenUrl",
+      type: "hidden",
+      default: "https://api.alterlab.io/api/v1/oauth/token",
+    },
+    {
+      displayName: "Client ID",
+      name: "clientId",
+      type: "hidden",
+      default: "n8n-community-node",
+    },
+    {
+      displayName: "Client Secret",
+      name: "clientSecret",
+      type: "hidden",
+      default: "altrlab_n8n_Kx7mP2vQ9wR4jH6nB3cT5zY8",
+    },
+    {
+      displayName: "Scope",
+      name: "scope",
+      type: "hidden",
+      default: "scrape",
+    },
+    {
+      displayName: "Auth URI Query Parameters",
+      name: "authQueryParameters",
+      type: "hidden",
+      default: "",
+    },
+    {
+      displayName: "Authentication",
+      name: "authentication",
+      type: "hidden",
+      default: "body",
+    },
+  ];
 
-	test: ICredentialTestRequest = {
-		request: {
-			baseURL: 'https://api.alterlab.io',
-			url: '/api/v1/usage',
-			method: 'GET',
-		},
-	};
+  test: ICredentialTestRequest = {
+    request: {
+      baseURL: "https://api.alterlab.io",
+      url: "/api/v1/usage",
+      method: "GET",
+    },
+  };
 }

--- a/nodes/AlterLab/AlterLab.node.ts
+++ b/nodes/AlterLab/AlterLab.node.ts
@@ -18,7 +18,7 @@ export class AlterLab implements INodeType {
     group: ["transform"],
     version: 1,
     subtitle:
-      '={{$parameter["resource"] === "session" ? "session " + $parameter["sessionOperation"] : ($parameter["operation"] === "estimateCost" ? "cost estimate" : $parameter["mode"] + " scrape")}}',
+      '={{$parameter["resource"] === "session" ? "session " + $parameter["sessionOperation"] : $parameter["resource"] === "crawl" ? "crawl " + $parameter["crawlOperation"] : $parameter["resource"] === "search" ? "search" : $parameter["resource"] === "map" ? "map" : $parameter["resource"] === "extract" ? "extract" : $parameter["resource"] === "batch" ? "batch scrape" : ($parameter["operation"] === "estimateCost" ? "cost estimate" : $parameter["mode"] + " scrape")}}',
     description:
       "Scrape any website with anti-bot bypass, JS rendering, structured extraction, OCR, and more",
     defaults: {
@@ -46,9 +46,36 @@ export class AlterLab implements INodeType {
         default: "scrape",
         options: [
           {
+            name: "Batch",
+            value: "batch",
+            description: "Submit up to 100 URLs for parallel scraping",
+          },
+          {
+            name: "Crawl",
+            value: "crawl",
+            description: "Discover and scrape entire websites",
+          },
+          {
+            name: "Extract",
+            value: "extract",
+            description:
+              "Run LLM extraction on raw content without fetching a URL",
+          },
+          {
+            name: "Map",
+            value: "map",
+            description:
+              "Discover all URLs on a site via sitemap and link crawling",
+          },
+          {
             name: "Scrape",
             value: "scrape",
             description: "Scrape websites and extract content",
+          },
+          {
+            name: "Search",
+            value: "search",
+            description: "Perform SERP searches and optionally scrape results",
           },
           {
             name: "Session",
@@ -169,12 +196,15 @@ export class AlterLab implements INodeType {
             type: "multiOptions",
             default: ["markdown", "json"],
             options: [
-              { name: "Markdown", value: "markdown" },
-              { name: "JSON", value: "json" },
               { name: "HTML", value: "html" },
+              { name: "JSON", value: "json" },
+              { name: "JSON V2 (Section Tree)", value: "json_v2" },
+              { name: "Markdown", value: "markdown" },
+              { name: "RAG (Chunked)", value: "rag" },
               { name: "Text", value: "text" },
             ],
-            description: "Output formats for content transformation",
+            description:
+              "Output formats for content transformation. json_v2 returns a structured section tree. rag returns chunked content for vector ingestion.",
           },
           {
             displayName: "Include Raw HTML",
@@ -279,6 +309,19 @@ export class AlterLab implements INodeType {
             },
           },
           {
+            displayName: "Scroll To Load",
+            name: "scrollToLoad",
+            type: "boolean",
+            default: false,
+            description:
+              "Whether to scroll the page to trigger lazy-loaded content (requires Render JavaScript). Adds ~2-3s latency.",
+            displayOptions: {
+              show: {
+                renderJs: [true],
+              },
+            },
+          },
+          {
             displayName: "OCR",
             name: "ocr",
             type: "boolean",
@@ -343,6 +386,25 @@ export class AlterLab implements INodeType {
             default: true,
             description:
               "Whether to remove cookie consent banners before content extraction",
+          },
+          {
+            displayName: "Cookies (JSON)",
+            name: "cookies",
+            type: "json",
+            default: "",
+            placeholder: '{"session-id": "abc123", "token": "xyz"}',
+            description:
+              "Inline cookies for one-off authenticated scraping as a JSON object (mutually exclusive with Session ID)",
+          },
+          {
+            displayName: "Section Filter (JSON)",
+            name: "sectionFilter",
+            type: "json",
+            default: "",
+            placeholder:
+              '{"min_content_blocks": 1, "content_only": false, "exclude_content_types": ["image"]}',
+            description:
+              "Filter options for json_v2 section tree output. Only applies when json_v2 is in formats. Keys: min_content_blocks (int), content_only (bool), exclude_content_types (array of: paragraph, list, table, image, code, blockquote, dl, details).",
           },
           {
             displayName: "Session ID",
@@ -498,6 +560,685 @@ export class AlterLab implements INodeType {
             default: false,
             description:
               "Whether to return an error instead of escalating to expensive tiers",
+          },
+        ],
+      },
+
+      // ══════════════════════════════════════════════════════
+      //  CRAWL RESOURCE
+      // ══════════════════════════════════════════════════════
+
+      {
+        displayName: "Operation",
+        name: "crawlOperation",
+        type: "options",
+        noDataExpression: true,
+        default: "start",
+        displayOptions: {
+          show: {
+            resource: ["crawl"],
+          },
+        },
+        options: [
+          {
+            name: "Start Crawl",
+            value: "start",
+            description:
+              "Start a new crawl and wait for it to complete (polling included)",
+            action: "Start a crawl",
+          },
+          {
+            name: "Get Status",
+            value: "status",
+            description: "Get the status and results of a crawl by ID",
+            action: "Get crawl status",
+          },
+          {
+            name: "Cancel",
+            value: "cancel",
+            description: "Cancel a running crawl and refund unused credits",
+            action: "Cancel a crawl",
+          },
+        ],
+        description: "The crawl operation to perform",
+      },
+
+      // ── Crawl ID (status / cancel) ──────────────────────
+      {
+        displayName: "Crawl ID",
+        name: "crawlId",
+        type: "string",
+        default: "",
+        required: true,
+        placeholder: "e.g. abc123...",
+        description: "The crawl ID returned by Start Crawl",
+        displayOptions: {
+          show: {
+            resource: ["crawl"],
+            crawlOperation: ["status", "cancel"],
+          },
+        },
+      },
+
+      // ── Crawl URL (start) ────────────────────────────────
+      {
+        displayName: "URL",
+        name: "crawlUrl",
+        type: "string",
+        default: "",
+        required: true,
+        placeholder: "https://www.example.com",
+        description: "The start URL for the crawl",
+        displayOptions: {
+          show: {
+            resource: ["crawl"],
+            crawlOperation: ["start"],
+          },
+        },
+      },
+
+      // ── Crawl Settings ───────────────────────────────────
+      {
+        displayName: "Crawl Settings",
+        name: "crawlSettings",
+        type: "collection",
+        placeholder: "Add Setting",
+        default: {},
+        displayOptions: {
+          show: {
+            resource: ["crawl"],
+            crawlOperation: ["start"],
+          },
+        },
+        options: [
+          {
+            displayName: "Max Pages",
+            name: "maxPages",
+            type: "number",
+            default: 50,
+            typeOptions: { minValue: 1, maxValue: 100000 },
+            description: "Maximum number of pages to scrape (1-100000)",
+          },
+          {
+            displayName: "Max Depth",
+            name: "maxDepth",
+            type: "number",
+            default: 3,
+            typeOptions: { minValue: 0, maxValue: 20 },
+            description:
+              "Maximum link-following depth from start URL (0 = start page only)",
+          },
+          {
+            displayName: "Formats",
+            name: "formats",
+            type: "multiOptions",
+            default: ["markdown"],
+            options: [
+              { name: "HTML", value: "html" },
+              { name: "JSON", value: "json" },
+              { name: "JSON V2 (Section Tree)", value: "json_v2" },
+              { name: "Markdown", value: "markdown" },
+              { name: "Text", value: "text" },
+            ],
+            description: "Output formats for each scraped page",
+          },
+          {
+            displayName: "Include Patterns",
+            name: "includePatterns",
+            type: "string",
+            default: "",
+            placeholder: "/blog/*,/products/*",
+            description:
+              "Comma-separated glob patterns — only scrape URLs matching at least one",
+          },
+          {
+            displayName: "Exclude Patterns",
+            name: "excludePatterns",
+            type: "string",
+            default: "",
+            placeholder: "/admin/*,/login",
+            description:
+              "Comma-separated glob patterns — skip URLs matching any",
+          },
+          {
+            displayName: "Sitemap Mode",
+            name: "sitemap",
+            type: "options",
+            default: "include",
+            options: [
+              {
+                name: "Include (Default)",
+                value: "include",
+                description: "Parse sitemap and follow links",
+              },
+              {
+                name: "Skip",
+                value: "skip",
+                description: "Skip sitemap, discover via links only",
+              },
+              {
+                name: "Only",
+                value: "only",
+                description:
+                  "Crawl exclusively from sitemap — no link extraction",
+              },
+            ],
+            description: "Sitemap discovery mode",
+          },
+          {
+            displayName: "Render JavaScript",
+            name: "renderJs",
+            type: "options",
+            default: "false",
+            options: [
+              {
+                name: "No",
+                value: "false",
+                description: "Do not render JavaScript",
+              },
+              {
+                name: "Yes",
+                value: "true",
+                description: "Always render with headless browser (Tier 4)",
+              },
+              {
+                name: "Auto",
+                value: "auto",
+                description:
+                  "Smart detection per page — saves 30-60% on mixed sites",
+              },
+            ],
+            description: "JavaScript rendering mode for crawled pages",
+          },
+          {
+            displayName: "Use Proxy",
+            name: "useProxy",
+            type: "boolean",
+            default: false,
+            description:
+              "Whether to route all crawl requests through premium proxy",
+          },
+          {
+            displayName: "Max Concurrency",
+            name: "maxConcurrency",
+            type: "number",
+            default: 10,
+            typeOptions: { minValue: 1, maxValue: 50 },
+            description: "Maximum concurrent pages to scrape simultaneously",
+          },
+          {
+            displayName: "Delay Between Requests (Seconds)",
+            name: "delay",
+            type: "number",
+            default: 0,
+            typeOptions: { minValue: 0, maxValue: 30 },
+            description: "Minimum seconds between requests to the same domain",
+          },
+          {
+            displayName: "Timeout Per Page (Seconds)",
+            name: "timeout",
+            type: "number",
+            default: 90,
+            typeOptions: { minValue: 1, maxValue: 300 },
+            description: "Timeout per page in seconds",
+          },
+          {
+            displayName: "Wait For Poll (Seconds)",
+            name: "pollTimeout",
+            type: "number",
+            default: 300,
+            typeOptions: { minValue: 10, maxValue: 3600 },
+            description:
+              "How long to wait for the crawl to complete before timing out (10-3600s)",
+          },
+        ],
+      },
+
+      // ══════════════════════════════════════════════════════
+      //  SEARCH RESOURCE
+      // ══════════════════════════════════════════════════════
+
+      {
+        displayName: "Query",
+        name: "searchQuery",
+        type: "string",
+        default: "",
+        required: true,
+        placeholder: "best web scraping API 2024",
+        description: "Search terms (max 500 characters)",
+        displayOptions: {
+          show: {
+            resource: ["search"],
+          },
+        },
+      },
+
+      {
+        displayName: "Search Options",
+        name: "searchOptions",
+        type: "collection",
+        placeholder: "Add Option",
+        default: {},
+        displayOptions: {
+          show: {
+            resource: ["search"],
+          },
+        },
+        options: [
+          {
+            displayName: "Number of Results",
+            name: "numResults",
+            type: "number",
+            default: 10,
+            typeOptions: { minValue: 1, maxValue: 30 },
+            description: "Number of results to return (1-30)",
+          },
+          {
+            displayName: "Page",
+            name: "page",
+            type: "number",
+            default: 1,
+            typeOptions: { minValue: 1, maxValue: 10 },
+            description: "Result page number (1-indexed)",
+          },
+          {
+            displayName: "Country",
+            name: "country",
+            type: "string",
+            default: "",
+            placeholder: "US",
+            description:
+              "ISO 3166-1 alpha-2 country code for geo-targeted results (e.g. US, GB, DE)",
+          },
+          {
+            displayName: "Language",
+            name: "language",
+            type: "string",
+            default: "",
+            placeholder: "en",
+            description: "Language code for results (e.g. en, fr, de)",
+          },
+          {
+            displayName: "Domain Filter",
+            name: "domain",
+            type: "string",
+            default: "",
+            placeholder: "example.com",
+            description:
+              "Restrict results to a specific domain (applied as site: prefix)",
+          },
+          {
+            displayName: "Time Range",
+            name: "timeRange",
+            type: "options",
+            default: "",
+            options: [
+              { name: "Any Time", value: "" },
+              { name: "Past Hour", value: "hour" },
+              { name: "Past Day", value: "day" },
+              { name: "Past Week", value: "week" },
+              { name: "Past Month", value: "month" },
+              { name: "Past Year", value: "year" },
+            ],
+            description: "Filter results by recency",
+          },
+          {
+            displayName: "Scrape Results",
+            name: "scrapeResults",
+            type: "boolean",
+            default: false,
+            description:
+              "Whether to scrape each result page and include content in response",
+          },
+          {
+            displayName: "Scrape Formats",
+            name: "scrapeFormats",
+            type: "multiOptions",
+            default: ["markdown"],
+            options: [
+              { name: "HTML", value: "html" },
+              { name: "JSON", value: "json" },
+              { name: "Markdown", value: "markdown" },
+              { name: "Text", value: "text" },
+            ],
+            description: "Output formats when Scrape Results is enabled",
+            displayOptions: {
+              show: {
+                scrapeResults: [true],
+              },
+            },
+          },
+          {
+            displayName: "Extraction Schema (JSON)",
+            name: "extractionSchema",
+            type: "json",
+            default: "",
+            placeholder: '{"title": "string", "price": "number"}',
+            description:
+              "JSON schema for structured extraction when Scrape Results is enabled",
+            displayOptions: {
+              show: {
+                scrapeResults: [true],
+              },
+            },
+          },
+        ],
+      },
+
+      // ══════════════════════════════════════════════════════
+      //  MAP RESOURCE
+      // ══════════════════════════════════════════════════════
+
+      {
+        displayName: "URL",
+        name: "mapUrl",
+        type: "string",
+        default: "",
+        required: true,
+        placeholder: "https://www.example.com",
+        description: "Starting URL for site discovery",
+        displayOptions: {
+          show: {
+            resource: ["map"],
+          },
+        },
+      },
+
+      {
+        displayName: "Map Options",
+        name: "mapOptions",
+        type: "collection",
+        placeholder: "Add Option",
+        default: {},
+        displayOptions: {
+          show: {
+            resource: ["map"],
+          },
+        },
+        options: [
+          {
+            displayName: "Max Pages",
+            name: "maxPages",
+            type: "number",
+            default: 500,
+            typeOptions: { minValue: 1, maxValue: 50000 },
+            description: "Maximum URLs to discover (1-50000)",
+          },
+          {
+            displayName: "Max Depth",
+            name: "maxDepth",
+            type: "number",
+            default: 3,
+            typeOptions: { minValue: 0, maxValue: 10 },
+            description: "Link-following depth (0 = start page + sitemap only)",
+          },
+          {
+            displayName: "Sitemap Mode",
+            name: "sitemap",
+            type: "options",
+            default: "include",
+            options: [
+              {
+                name: "Include (Default)",
+                value: "include",
+                description: "Parse sitemaps and follow links",
+              },
+              {
+                name: "Skip",
+                value: "skip",
+                description: "Ignore sitemaps",
+              },
+              {
+                name: "Only",
+                value: "only",
+                description: "Return only sitemap URLs without link following",
+              },
+            ],
+            description: "Sitemap discovery mode",
+          },
+          {
+            displayName: "Include Patterns",
+            name: "includePatterns",
+            type: "string",
+            default: "",
+            placeholder: "/blog/*,/products/*",
+            description:
+              "Comma-separated glob patterns — only include URLs matching at least one",
+          },
+          {
+            displayName: "Exclude Patterns",
+            name: "excludePatterns",
+            type: "string",
+            default: "",
+            placeholder: "/admin/*,/login",
+            description:
+              "Comma-separated glob patterns — exclude URLs matching any",
+          },
+          {
+            displayName: "Search Filter",
+            name: "search",
+            type: "string",
+            default: "",
+            placeholder: "pricing documentation",
+            description: "Query to filter/rank discovered URLs by relevance",
+          },
+          {
+            displayName: "Include Metadata",
+            name: "includeMetadata",
+            type: "boolean",
+            default: false,
+            description:
+              "Whether to fetch title and meta description for each URL (slower)",
+          },
+          {
+            displayName: "Include Subdomains",
+            name: "includeSubdomains",
+            type: "boolean",
+            default: false,
+            description:
+              "Whether to include URLs from subdomains of the target domain",
+          },
+          {
+            displayName: "Respect Robots.txt",
+            name: "respectRobots",
+            type: "boolean",
+            default: true,
+            description: "Whether to respect robots.txt directives",
+          },
+          {
+            displayName: "Custom Sitemap Path",
+            name: "sitemapPath",
+            type: "string",
+            default: "",
+            placeholder: "/custom-sitemap.xml",
+            description: "Custom sitemap location (must start with /)",
+          },
+        ],
+      },
+
+      // ══════════════════════════════════════════════════════
+      //  EXTRACT RESOURCE
+      // ══════════════════════════════════════════════════════
+
+      {
+        displayName: "Content",
+        name: "extractContent",
+        type: "string",
+        typeOptions: { rows: 6 },
+        default: "",
+        required: true,
+        placeholder: "<html>...</html> or raw text / markdown",
+        description:
+          "Raw content to extract from (HTML, text, or markdown — max 5 MB)",
+        displayOptions: {
+          show: {
+            resource: ["extract"],
+          },
+        },
+      },
+
+      {
+        displayName: "Content Type",
+        name: "extractContentType",
+        type: "options",
+        default: "html",
+        displayOptions: {
+          show: {
+            resource: ["extract"],
+          },
+        },
+        options: [
+          { name: "HTML", value: "html" },
+          { name: "Markdown", value: "markdown" },
+          { name: "Text", value: "text" },
+        ],
+        description: "Type of the provided content",
+      },
+
+      {
+        displayName: "Extract Options",
+        name: "extractOptions",
+        type: "collection",
+        placeholder: "Add Option",
+        default: {},
+        displayOptions: {
+          show: {
+            resource: ["extract"],
+          },
+        },
+        options: [
+          {
+            displayName: "Formats",
+            name: "formats",
+            type: "multiOptions",
+            default: ["json"],
+            options: [
+              { name: "HTML", value: "html" },
+              { name: "JSON", value: "json" },
+              { name: "JSON V2 (Section Tree)", value: "json_v2" },
+              { name: "Markdown", value: "markdown" },
+              { name: "RAG (Chunked)", value: "rag" },
+              { name: "Text", value: "text" },
+            ],
+            description: "Output formats for content transformation",
+          },
+          {
+            displayName: "Extraction Schema (JSON)",
+            name: "extractionSchema",
+            type: "json",
+            default: "",
+            placeholder: '{"title": "string", "price": "number"}',
+            description: "JSON Schema for structured extraction",
+          },
+          {
+            displayName: "Extraction Profile",
+            name: "extractionProfile",
+            type: "options",
+            default: "",
+            options: [
+              { name: "None", value: "" },
+              { name: "Auto", value: "auto" },
+              { name: "Article", value: "article" },
+              { name: "Event", value: "event" },
+              { name: "FAQ", value: "faq" },
+              { name: "Job Posting", value: "job_posting" },
+              { name: "Product", value: "product" },
+              { name: "Recipe", value: "recipe" },
+            ],
+            description: "Pre-defined extraction profile (schema template)",
+          },
+          {
+            displayName: "Extraction Prompt",
+            name: "extractionPrompt",
+            type: "string",
+            typeOptions: { rows: 4 },
+            default: "",
+            placeholder: "Extract the product name, price, and availability...",
+            description: "Natural language extraction instructions for the LLM",
+          },
+          {
+            displayName: "Source URL",
+            name: "sourceUrl",
+            type: "string",
+            default: "",
+            placeholder: "https://www.example.com/page",
+            description:
+              "Original URL of the content (for context only, not fetched)",
+          },
+          {
+            displayName: "Evidence",
+            name: "evidence",
+            type: "boolean",
+            default: false,
+            description:
+              "Whether to include provenance/evidence for extracted fields",
+          },
+        ],
+      },
+
+      // ══════════════════════════════════════════════════════
+      //  BATCH RESOURCE
+      // ══════════════════════════════════════════════════════
+
+      {
+        displayName: "URLs (JSON Array)",
+        name: "batchUrls",
+        type: "json",
+        default: "[]",
+        required: true,
+        placeholder:
+          '[{"url": "https://example.com"}, {"url": "https://example.org", "mode": "js"}]',
+        description:
+          'Array of URL objects to scrape in parallel (max 100). Each item: { url, mode?, formats?, advanced?, cost_controls? }. Example: [{"url": "https://example.com", "mode": "auto", "formats": ["markdown"]}]',
+        displayOptions: {
+          show: {
+            resource: ["batch"],
+          },
+        },
+      },
+
+      {
+        displayName: "Batch Options",
+        name: "batchOptions",
+        type: "collection",
+        placeholder: "Add Option",
+        default: {},
+        displayOptions: {
+          show: {
+            resource: ["batch"],
+          },
+        },
+        options: [
+          {
+            displayName: "Webhook URL",
+            name: "webhookUrl",
+            type: "string",
+            default: "",
+            placeholder: "https://your-server.com/webhook",
+            description:
+              "Webhook URL to receive a batch.completed event when all jobs finish",
+          },
+          {
+            displayName: "Wait For Completion",
+            name: "waitForCompletion",
+            type: "boolean",
+            default: true,
+            description:
+              "Whether to poll until all batch jobs complete before returning results",
+          },
+          {
+            displayName: "Poll Timeout (Seconds)",
+            name: "pollTimeout",
+            type: "number",
+            default: 300,
+            typeOptions: { minValue: 10, maxValue: 3600 },
+            description:
+              "How long to wait for the batch to complete (10-3600s)",
+            displayOptions: {
+              show: {
+                waitForCompletion: [true],
+              },
+            },
           },
         ],
       },
@@ -1212,6 +1953,619 @@ export class AlterLab implements INodeType {
         }
 
         // ══════════════════════════════════════════════════
+        //  CRAWL RESOURCE
+        // ══════════════════════════════════════════════════
+        if (resource === "crawl") {
+          const crawlOp = this.getNodeParameter("crawlOperation", i) as string;
+
+          if (crawlOp === "status") {
+            const crawlId = this.getNodeParameter("crawlId", i) as string;
+
+            const response =
+              await this.helpers.httpRequestWithAuthentication.call(
+                this,
+                authName,
+                {
+                  method: "GET",
+                  url: `/api/v1/crawl/${crawlId}`,
+                  json: true,
+                  returnFullResponse: true,
+                  ignoreHttpStatusErrors: true,
+                },
+              );
+
+            const statusCode = (response as { statusCode: number }).statusCode;
+            const responseBody = (response as { body: Record<string, unknown> })
+              .body;
+
+            if (statusCode >= 400) {
+              handleApiError(this, statusCode, responseBody as JsonObject, i);
+            }
+
+            results.push({ json: responseBody as IDataObject });
+            continue;
+          }
+
+          if (crawlOp === "cancel") {
+            const crawlId = this.getNodeParameter("crawlId", i) as string;
+
+            const response =
+              await this.helpers.httpRequestWithAuthentication.call(
+                this,
+                authName,
+                {
+                  method: "DELETE",
+                  url: `/api/v1/crawl/${crawlId}`,
+                  json: true,
+                  returnFullResponse: true,
+                  ignoreHttpStatusErrors: true,
+                },
+              );
+
+            const statusCode = (response as { statusCode: number }).statusCode;
+            const responseBody = (response as { body: Record<string, unknown> })
+              .body;
+
+            if (statusCode >= 400) {
+              handleApiError(this, statusCode, responseBody as JsonObject, i);
+            }
+
+            results.push({ json: responseBody as IDataObject });
+            continue;
+          }
+
+          if (crawlOp === "start") {
+            const crawlUrl = this.getNodeParameter("crawlUrl", i) as string;
+            const settings = this.getNodeParameter("crawlSettings", i, {}) as {
+              maxPages?: number;
+              maxDepth?: number;
+              formats?: string[];
+              includePatterns?: string;
+              excludePatterns?: string;
+              sitemap?: string;
+              renderJs?: string;
+              useProxy?: boolean;
+              maxConcurrency?: number;
+              delay?: number;
+              timeout?: number;
+              pollTimeout?: number;
+            };
+
+            const body: Record<string, unknown> = { url: crawlUrl };
+
+            if (settings.maxPages && settings.maxPages !== 50)
+              body.max_pages = settings.maxPages;
+            if (settings.maxDepth !== undefined && settings.maxDepth !== 3)
+              body.max_depth = settings.maxDepth;
+            if (settings.formats?.length) body.formats = settings.formats;
+            if (settings.includePatterns) {
+              body.include_patterns = settings.includePatterns
+                .split(",")
+                .map((p) => p.trim())
+                .filter(Boolean);
+            }
+            if (settings.excludePatterns) {
+              body.exclude_patterns = settings.excludePatterns
+                .split(",")
+                .map((p) => p.trim())
+                .filter(Boolean);
+            }
+            if (settings.sitemap && settings.sitemap !== "include") {
+              body.sitemap = settings.sitemap;
+            }
+
+            const advanced: Record<string, unknown> = {};
+            if (settings.renderJs && settings.renderJs !== "false") {
+              advanced.render_js = settings.renderJs === "auto" ? "auto" : true;
+            }
+            if (settings.useProxy) advanced.use_proxy = true;
+            if (settings.maxConcurrency && settings.maxConcurrency !== 10) {
+              advanced.max_concurrency = settings.maxConcurrency;
+            }
+            if (settings.delay && settings.delay > 0) {
+              advanced.delay = settings.delay;
+            }
+            if (settings.timeout && settings.timeout !== 90) {
+              advanced.timeout = settings.timeout;
+            }
+            if (Object.keys(advanced).length > 0) body.advanced = advanced;
+
+            // Submit the crawl
+            const startResponse =
+              await this.helpers.httpRequestWithAuthentication.call(
+                this,
+                authName,
+                {
+                  method: "POST",
+                  url: "/api/v1/crawl",
+                  body,
+                  json: true,
+                  returnFullResponse: true,
+                  ignoreHttpStatusErrors: true,
+                },
+              );
+
+            const startStatus = (startResponse as { statusCode: number })
+              .statusCode;
+            const startBody = (
+              startResponse as { body: Record<string, unknown> }
+            ).body;
+
+            if (startStatus >= 400) {
+              handleApiError(this, startStatus, startBody as JsonObject, i);
+            }
+
+            const crawlId = (startBody as Record<string, unknown>)
+              .crawl_id as string;
+
+            if (!crawlId) {
+              throw new NodeOperationError(
+                this.getNode(),
+                "No crawl_id returned from API",
+                { itemIndex: i },
+              );
+            }
+
+            // Poll until complete or timeout
+            const pollTimeoutMs = (settings.pollTimeout ?? 300) * 1000;
+            const pollStart = Date.now();
+            let pollDelay = 2000;
+            const maxPollDelay = 10000;
+            let finalBody: Record<string, unknown> = startBody;
+
+            while (Date.now() - pollStart < pollTimeoutMs) {
+              await new Promise<void>((resolve) => {
+                setTimeout(resolve, pollDelay);
+              });
+              pollDelay = Math.min(pollDelay * 1.5, maxPollDelay);
+
+              const pollResponse =
+                await this.helpers.httpRequestWithAuthentication.call(
+                  this,
+                  authName,
+                  {
+                    method: "GET",
+                    url: `/api/v1/crawl/${crawlId}`,
+                    json: true,
+                    returnFullResponse: true,
+                    ignoreHttpStatusErrors: true,
+                  },
+                );
+
+              const pollStatus = (pollResponse as { statusCode: number })
+                .statusCode;
+              const pollBody = (
+                pollResponse as { body: Record<string, unknown> }
+              ).body;
+
+              if (pollStatus >= 400) {
+                handleApiError(this, pollStatus, pollBody as JsonObject, i);
+              }
+
+              finalBody = pollBody;
+              const crawlStatus = (pollBody as Record<string, unknown>)
+                .status as string;
+
+              if (
+                crawlStatus === "completed" ||
+                crawlStatus === "cancelled" ||
+                crawlStatus === "failed"
+              ) {
+                break;
+              }
+            }
+
+            const finalStatus = (finalBody as Record<string, unknown>)
+              .status as string;
+            results.push({
+              json: {
+                ...(finalBody as IDataObject),
+                crawlId,
+                timedOut: finalStatus !== "completed",
+              },
+            });
+            continue;
+          }
+
+          throw new NodeOperationError(
+            this.getNode(),
+            `Unknown crawl operation: ${crawlOp}`,
+            { itemIndex: i },
+          );
+        }
+
+        // ══════════════════════════════════════════════════
+        //  SEARCH RESOURCE
+        // ══════════════════════════════════════════════════
+        if (resource === "search") {
+          const query = this.getNodeParameter("searchQuery", i) as string;
+          const opts = this.getNodeParameter("searchOptions", i, {}) as {
+            numResults?: number;
+            page?: number;
+            country?: string;
+            language?: string;
+            domain?: string;
+            timeRange?: string;
+            scrapeResults?: boolean;
+            scrapeFormats?: string[];
+            extractionSchema?: string;
+          };
+
+          const body: Record<string, unknown> = { query };
+          if (opts.numResults && opts.numResults !== 10)
+            body.num_results = opts.numResults;
+          if (opts.page && opts.page !== 1) body.page = opts.page;
+          if (opts.country) body.country = opts.country.toUpperCase();
+          if (opts.language) body.language = opts.language.toLowerCase();
+          if (opts.domain) body.domain = opts.domain;
+          if (opts.timeRange) body.time_range = opts.timeRange;
+          if (opts.scrapeResults) {
+            body.scrape_results = true;
+            if (opts.scrapeFormats?.length) body.formats = opts.scrapeFormats;
+            if (opts.extractionSchema) {
+              try {
+                body.extraction_schema =
+                  typeof opts.extractionSchema === "string"
+                    ? JSON.parse(opts.extractionSchema)
+                    : opts.extractionSchema;
+              } catch {
+                throw new NodeOperationError(
+                  this.getNode(),
+                  "Invalid JSON in Extraction Schema field",
+                  { itemIndex: i },
+                );
+              }
+            }
+          }
+
+          const response =
+            await this.helpers.httpRequestWithAuthentication.call(
+              this,
+              authName,
+              {
+                method: "POST",
+                url: "/api/v1/search",
+                body,
+                json: true,
+                returnFullResponse: true,
+                ignoreHttpStatusErrors: true,
+              },
+            );
+
+          const statusCode = (response as { statusCode: number }).statusCode;
+          const responseBody = (response as { body: Record<string, unknown> })
+            .body;
+
+          if (statusCode >= 400) {
+            handleApiError(this, statusCode, responseBody as JsonObject, i);
+          }
+
+          const data = responseBody as Record<string, unknown>;
+
+          // If scrape_results returned async (202 or status=scraping), poll for completion
+          if (statusCode === 202 || (data.status as string) === "scraping") {
+            const searchId = data.search_id as string;
+            if (searchId) {
+              let searchPollDelay = 1000;
+              const maxSearchPollDelay = 5000;
+              const searchPollStart = Date.now();
+              const maxSearchPollMs = 120_000; // 2 min max
+
+              let finalData = data;
+              while (Date.now() - searchPollStart < maxSearchPollMs) {
+                await new Promise<void>((resolve) => {
+                  setTimeout(resolve, searchPollDelay);
+                });
+                searchPollDelay = Math.min(
+                  searchPollDelay * 1.5,
+                  maxSearchPollDelay,
+                );
+
+                const pollResp =
+                  await this.helpers.httpRequestWithAuthentication.call(
+                    this,
+                    authName,
+                    {
+                      method: "GET",
+                      url: `/api/v1/search/${searchId}`,
+                      json: true,
+                      returnFullResponse: true,
+                      ignoreHttpStatusErrors: true,
+                    },
+                  );
+
+                const pollStatus = (pollResp as { statusCode: number })
+                  .statusCode;
+                const pollBody = (pollResp as { body: Record<string, unknown> })
+                  .body;
+
+                if (pollStatus >= 400) {
+                  handleApiError(this, pollStatus, pollBody as JsonObject, i);
+                }
+
+                finalData = pollBody as Record<string, unknown>;
+                if ((finalData.status as string) === "completed") break;
+              }
+
+              results.push({ json: finalData as IDataObject });
+              continue;
+            }
+          }
+
+          results.push({ json: data as IDataObject });
+          continue;
+        }
+
+        // ══════════════════════════════════════════════════
+        //  MAP RESOURCE
+        // ══════════════════════════════════════════════════
+        if (resource === "map") {
+          const mapUrl = this.getNodeParameter("mapUrl", i) as string;
+          const opts = this.getNodeParameter("mapOptions", i, {}) as {
+            maxPages?: number;
+            maxDepth?: number;
+            sitemap?: string;
+            includePatterns?: string;
+            excludePatterns?: string;
+            search?: string;
+            includeMetadata?: boolean;
+            includeSubdomains?: boolean;
+            respectRobots?: boolean;
+            sitemapPath?: string;
+          };
+
+          const body: Record<string, unknown> = { url: mapUrl };
+          if (opts.maxPages && opts.maxPages !== 500)
+            body.max_pages = opts.maxPages;
+          if (opts.maxDepth !== undefined && opts.maxDepth !== 3)
+            body.max_depth = opts.maxDepth;
+          if (opts.sitemap && opts.sitemap !== "include")
+            body.sitemap = opts.sitemap;
+          if (opts.includePatterns) {
+            body.include_patterns = opts.includePatterns
+              .split(",")
+              .map((p) => p.trim())
+              .filter(Boolean);
+          }
+          if (opts.excludePatterns) {
+            body.exclude_patterns = opts.excludePatterns
+              .split(",")
+              .map((p) => p.trim())
+              .filter(Boolean);
+          }
+          if (opts.search) body.search = opts.search;
+          if (opts.includeMetadata) body.include_metadata = true;
+          if (opts.includeSubdomains) body.include_subdomains = true;
+          if (opts.respectRobots === false) body.respect_robots = false;
+          if (opts.sitemapPath) body.sitemap_path = opts.sitemapPath;
+
+          const response =
+            await this.helpers.httpRequestWithAuthentication.call(
+              this,
+              authName,
+              {
+                method: "POST",
+                url: "/api/v1/map",
+                body,
+                json: true,
+                returnFullResponse: true,
+                ignoreHttpStatusErrors: true,
+              },
+            );
+
+          const statusCode = (response as { statusCode: number }).statusCode;
+          const responseBody = (response as { body: Record<string, unknown> })
+            .body;
+
+          if (statusCode >= 400) {
+            handleApiError(this, statusCode, responseBody as JsonObject, i);
+          }
+
+          results.push({ json: responseBody as IDataObject });
+          continue;
+        }
+
+        // ══════════════════════════════════════════════════
+        //  EXTRACT RESOURCE
+        // ══════════════════════════════════════════════════
+        if (resource === "extract") {
+          const content = this.getNodeParameter("extractContent", i) as string;
+          const contentType = this.getNodeParameter(
+            "extractContentType",
+            i,
+          ) as string;
+          const opts = this.getNodeParameter("extractOptions", i, {}) as {
+            formats?: string[];
+            extractionSchema?: string;
+            extractionProfile?: string;
+            extractionPrompt?: string;
+            sourceUrl?: string;
+            evidence?: boolean;
+          };
+
+          const body: Record<string, unknown> = {
+            content,
+            content_type: contentType,
+          };
+
+          if (opts.formats?.length) body.formats = opts.formats;
+          if (opts.extractionSchema) {
+            try {
+              body.extraction_schema =
+                typeof opts.extractionSchema === "string"
+                  ? JSON.parse(opts.extractionSchema)
+                  : opts.extractionSchema;
+            } catch {
+              throw new NodeOperationError(
+                this.getNode(),
+                "Invalid JSON in Extraction Schema field",
+                { itemIndex: i },
+              );
+            }
+          }
+          if (opts.extractionProfile)
+            body.extraction_profile = opts.extractionProfile;
+          if (opts.extractionPrompt)
+            body.extraction_prompt = opts.extractionPrompt;
+          if (opts.sourceUrl) body.source_url = opts.sourceUrl;
+          if (opts.evidence) body.evidence = true;
+
+          const response =
+            await this.helpers.httpRequestWithAuthentication.call(
+              this,
+              authName,
+              {
+                method: "POST",
+                url: "/api/v1/extract",
+                body,
+                json: true,
+                returnFullResponse: true,
+                ignoreHttpStatusErrors: true,
+              },
+            );
+
+          const statusCode = (response as { statusCode: number }).statusCode;
+          const responseBody = (response as { body: Record<string, unknown> })
+            .body;
+
+          if (statusCode >= 400) {
+            handleApiError(this, statusCode, responseBody as JsonObject, i);
+          }
+
+          const data = responseBody as Record<string, unknown>;
+          const formats = data.formats as Record<string, unknown> | undefined;
+
+          const output: IDataObject = {
+            extractId: data.extract_id ?? null,
+            creditsUsed: data.credits_used ?? 0,
+            modelUsed: data.model_used ?? null,
+            extractionMethod: data.extraction_method ?? "algorithmic",
+            contentSizeChars: data.content_size_chars ?? 0,
+          };
+
+          // Flatten format results into top-level keys
+          if (formats && typeof formats === "object") {
+            if (formats.text !== undefined) output.text = formats.text;
+            if (formats.markdown !== undefined)
+              output.markdown = formats.markdown;
+            if (formats.html !== undefined) output.html = formats.html;
+            if (formats.json !== undefined) output.json = formats.json;
+            if (formats.json_v2 !== undefined) output.jsonV2 = formats.json_v2;
+            if (formats.rag !== undefined) output.rag = formats.rag;
+          }
+
+          results.push({ json: output });
+          continue;
+        }
+
+        // ══════════════════════════════════════════════════
+        //  BATCH RESOURCE
+        // ══════════════════════════════════════════════════
+        if (resource === "batch") {
+          const urlsRaw = this.getNodeParameter("batchUrls", i) as string;
+          const opts = this.getNodeParameter("batchOptions", i, {}) as {
+            webhookUrl?: string;
+            waitForCompletion?: boolean;
+            pollTimeout?: number;
+          };
+
+          let urls: unknown[];
+          try {
+            urls = typeof urlsRaw === "string" ? JSON.parse(urlsRaw) : urlsRaw;
+            if (!Array.isArray(urls)) {
+              throw new Error("URLs must be an array");
+            }
+          } catch {
+            throw new NodeOperationError(
+              this.getNode(),
+              "Invalid JSON in URLs field — must be an array of URL objects",
+              { itemIndex: i },
+            );
+          }
+
+          const body: Record<string, unknown> = { urls };
+          if (opts.webhookUrl) body.webhook_url = opts.webhookUrl;
+
+          const submitResponse =
+            await this.helpers.httpRequestWithAuthentication.call(
+              this,
+              authName,
+              {
+                method: "POST",
+                url: "/api/v1/batch",
+                body,
+                json: true,
+                returnFullResponse: true,
+                ignoreHttpStatusErrors: true,
+              },
+            );
+
+          const submitStatus = (submitResponse as { statusCode: number })
+            .statusCode;
+          const submitBody = (
+            submitResponse as { body: Record<string, unknown> }
+          ).body;
+
+          if (submitStatus >= 400) {
+            handleApiError(this, submitStatus, submitBody as JsonObject, i);
+          }
+
+          const batchId = (submitBody as Record<string, unknown>)
+            .batch_id as string;
+
+          if (!batchId || opts.waitForCompletion === false) {
+            results.push({ json: submitBody as IDataObject });
+            continue;
+          }
+
+          // Poll until complete or timeout
+          const batchPollTimeoutMs = (opts.pollTimeout ?? 300) * 1000;
+          const batchPollStart = Date.now();
+          let batchDelay = 1000;
+          const maxBatchDelay = 8000;
+          let finalBatchBody: Record<string, unknown> = submitBody;
+
+          while (Date.now() - batchPollStart < batchPollTimeoutMs) {
+            await new Promise<void>((resolve) => {
+              setTimeout(resolve, batchDelay);
+            });
+            batchDelay = Math.min(batchDelay * 1.5, maxBatchDelay);
+
+            const pollResponse =
+              await this.helpers.httpRequestWithAuthentication.call(
+                this,
+                authName,
+                {
+                  method: "GET",
+                  url: `/api/v1/batch/${batchId}`,
+                  json: true,
+                  returnFullResponse: true,
+                  ignoreHttpStatusErrors: true,
+                },
+              );
+
+            const pollStatus = (pollResponse as { statusCode: number })
+              .statusCode;
+            const pollBody = (pollResponse as { body: Record<string, unknown> })
+              .body;
+
+            if (pollStatus >= 400) {
+              handleApiError(this, pollStatus, pollBody as JsonObject, i);
+            }
+
+            finalBatchBody = pollBody;
+            const batchStatus = (pollBody as Record<string, unknown>)
+              .status as string;
+            if (batchStatus === "completed" || batchStatus === "failed") {
+              break;
+            }
+          }
+
+          results.push({ json: finalBatchBody as IDataObject });
+          continue;
+        }
+
+        // ══════════════════════════════════════════════════
         //  SCRAPE RESOURCE
         // ══════════════════════════════════════════════════
         const operation = this.getNodeParameter("operation", i) as string;
@@ -1318,11 +2672,14 @@ export class AlterLab implements INodeType {
           renderJs?: boolean;
           screenshot?: boolean;
           generatePdf?: boolean;
+          scrollToLoad?: boolean;
           ocr?: boolean;
           useProxy?: boolean;
           proxyCountry?: string;
           waitCondition?: string;
           removeCookieBanners?: boolean;
+          cookies?: string;
+          sectionFilter?: string;
           sessionId?: string;
         };
         const extraction = this.getNodeParameter("extraction", i, {}) as {
@@ -1372,6 +2729,7 @@ export class AlterLab implements INodeType {
         if (advancedOptions.renderJs) advanced.render_js = true;
         if (advancedOptions.screenshot) advanced.screenshot = true;
         if (advancedOptions.generatePdf) advanced.generate_pdf = true;
+        if (advancedOptions.scrollToLoad) advanced.scroll_to_load = true;
         if (advancedOptions.ocr) advanced.ocr = true;
         if (advancedOptions.useProxy) advanced.use_proxy = true;
         if (advancedOptions.proxyCountry) {
@@ -1385,6 +2743,34 @@ export class AlterLab implements INodeType {
         }
         if (advancedOptions.removeCookieBanners === false) {
           advanced.remove_cookie_banners = false;
+        }
+        if (advancedOptions.cookies) {
+          try {
+            advanced.cookies =
+              typeof advancedOptions.cookies === "string"
+                ? JSON.parse(advancedOptions.cookies)
+                : advancedOptions.cookies;
+          } catch {
+            throw new NodeOperationError(
+              this.getNode(),
+              "Invalid JSON in Cookies field",
+              { itemIndex: i },
+            );
+          }
+        }
+        if (advancedOptions.sectionFilter) {
+          try {
+            advanced.section_filter =
+              typeof advancedOptions.sectionFilter === "string"
+                ? JSON.parse(advancedOptions.sectionFilter)
+                : advancedOptions.sectionFilter;
+          } catch {
+            throw new NodeOperationError(
+              this.getNode(),
+              "Invalid JSON in Section Filter field",
+              { itemIndex: i },
+            );
+          }
         }
         if (advancedOptions.sessionId) {
           advanced.session_id = advancedOptions.sessionId;
@@ -1542,6 +2928,8 @@ export class AlterLab implements INodeType {
             (content as Record<string, unknown>).markdown ?? null;
           output.text = (content as Record<string, unknown>).text ?? null;
           output.json = (content as Record<string, unknown>).json ?? null;
+          output.jsonV2 = (content as Record<string, unknown>).json_v2 ?? null;
+          output.rag = (content as Record<string, unknown>).rag ?? null;
           output.html = (content as Record<string, unknown>).html ?? null;
         } else {
           output.markdown = content ?? null;


### PR DESCRIPTION
## Summary

- Add **Crawl** resource (start with completion polling, get status, cancel)
- Add **Search** resource (SERP search with optional per-result scraping and async polling)
- Add **Map** resource (site URL discovery via sitemap + link crawling, with filters)
- Add **Extract** resource (standalone LLM extraction from raw HTML/text/markdown)
- Add **Batch** resource (parallel scraping of up to 100 URLs with completion polling)
- Add `json_v2` (section tree) and `rag` (chunked) to Scrape output formats
- Add `cookies`, `scroll_to_load`, and `section_filter` to Scrape Advanced Options
- Update subtitle expression to cover all 7 resource types

Resolves ecosystem sync gap: the node previously only exposed Scrape and Session resources while the API had shipped crawl, search, map, extract, and batch endpoints.