### PR TITLE
Feat: n8n Node — add HTTP method and request body to scrape resource

### DIFF
--- a/nodes/AlterLab/AlterLab.node.ts
+++ b/nodes/AlterLab/AlterLab.node.ts
@@ -176,6 +176,65 @@ export class AlterLab implements INodeType {
         },
       },
 
+      // ── HTTP Method ──────────────────────────────────────
+      {
+        displayName: "HTTP Method",
+        name: "httpMethod",
+        type: "options",
+        default: "GET",
+        displayOptions: {
+          show: {
+            resource: ["scrape"],
+          },
+        },
+        options: [
+          {
+            name: "GET",
+            value: "GET",
+            description: "Standard page scraping (default)",
+          },
+          {
+            name: "POST",
+            value: "POST",
+            description: "Form submissions, REST APIs, GraphQL",
+          },
+          {
+            name: "PUT",
+            value: "PUT",
+            description: "Full resource replacement",
+          },
+          {
+            name: "PATCH",
+            value: "PATCH",
+            description: "Partial resource update",
+          },
+          {
+            name: "DELETE",
+            value: "DELETE",
+            description: "Resource deletion",
+          },
+        ],
+        description: "HTTP method for the target URL request",
+      },
+
+      // ── Request Body ─────────────────────────────────────
+      {
+        displayName: "Request Body",
+        name: "requestBody",
+        type: "string",
+        typeOptions: { rows: 4 },
+        default: "",
+        placeholder: '{"query": "{ user { id name } }"}',
+        displayOptions: {
+          show: {
+            resource: ["scrape"],
+            httpMethod: ["POST", "PUT", "PATCH"],
+          },
+        },
+        description:
+          "Request body as a string. For GraphQL: JSON with query + variables. For REST: JSON payload. For forms: URL-encoded string.",
+      },
+
       // ── Output Options ───────────────────────────────────
       {
         displayName: "Output Options",
@@ -2655,6 +2714,16 @@ export class AlterLab implements INodeType {
         }
 
         // ── Scrape operation ──────────────────────────────
+        const httpMethod = this.getNodeParameter(
+          "httpMethod",
+          i,
+          "GET",
+        ) as string;
+        const requestBody = this.getNodeParameter(
+          "requestBody",
+          i,
+          "",
+        ) as string;
         const outputOptions = this.getNodeParameter("outputOptions", i, {}) as {
           formats?: string[];
           includeRawHtml?: boolean;
@@ -2704,6 +2773,14 @@ export class AlterLab implements INodeType {
           mode,
           sync: true,
         };
+
+        // HTTP method and request body
+        if (httpMethod && httpMethod !== "GET") {
+          body.method = httpMethod;
+        }
+        if (requestBody && requestBody.trim()) {
+          body.body = requestBody;
+        }
 
         // Output options
         if (outputOptions.formats?.length) {


### PR DESCRIPTION
## Summary

Adds `httpMethod` dropdown and `requestBody` text field to the n8n scrape resource, enabling POST/PUT/PATCH/DELETE requests with custom bodies.

- **HTTP Method dropdown** — GET/POST/PUT/PATCH/DELETE; default GET (backward-compatible)
- **Request Body field** — multiline text, shown only when method is POST/PUT/PATCH
- Both fields are forwarded to the AlterLab `/api/v1/scrape` endpoint as `method` and `body` fields

Enables API chaining, GraphQL query relay, and form submission workflows in n8n.

## Changes

- `nodes/AlterLab/AlterLab.node.ts`: +77 lines — 2 new node properties + execution wiring

## Testing

- [x] `npm run build` passes without TypeScript errors
- [x] Default behavior unchanged — GET selected by default, no body field shown
- [x] Request Body only visible for POST/PUT/PATCH (displayOptions conditional)
- [x] `method` field only forwarded when not GET
- [x] `body` field only forwarded when non-empty

Closes #12311 (RapierCraftStudios/AlterLab)