### PR TITLE
Feat: add max_response_bytes output option to Scrape operation

### DIFF
--- a/nodes/AlterLab/AlterLab.node.ts
+++ b/nodes/AlterLab/AlterLab.node.ts
@@ -280,6 +280,15 @@ export class AlterLab implements INodeType {
             typeOptions: { minValue: 1, maxValue: 300 },
             description: "Request timeout in seconds (1-300)",
           },
+          {
+            displayName: "Max Response Bytes",
+            name: "maxResponseBytes",
+            type: "number",
+            default: 5242880,
+            typeOptions: { minValue: 0, maxValue: 52428800 },
+            description:
+              "Soft cap on raw response body size in bytes. HTML exceeding this limit is truncated before extraction. Default: 5 MB (5242880). Set to 0 for no limit. Maximum: 50 MB (52428800).",
+          },
         ],
       },
 
@@ -2728,6 +2737,7 @@ export class AlterLab implements INodeType {
           formats?: string[];
           includeRawHtml?: boolean;
           timeout?: number;
+          maxResponseBytes?: number;
         };
         const executionMode = this.getNodeParameter("executionMode", i, {}) as {
           cache?: boolean;
@@ -2791,6 +2801,12 @@ export class AlterLab implements INodeType {
         }
         if (outputOptions.timeout && outputOptions.timeout !== 90) {
           body.timeout = outputOptions.timeout;
+        }
+        if (
+          outputOptions.maxResponseBytes !== undefined &&
+          outputOptions.maxResponseBytes !== 5242880
+        ) {
+          body.max_response_bytes = outputOptions.maxResponseBytes;
         }
 
         // Execution mode


### PR DESCRIPTION
## Summary

Adds the `max_response_bytes` parameter to the n8n node's Scrape operation Output Options, syncing with the AlterLab API change from PR #12357.

**Changes:**
- New `Max Response Bytes` field in Output Options (number, default 5 MB, 0–50 MB range)
- TypeScript interface updated with `maxResponseBytes?: number`
- Execution body wiring: sends `max_response_bytes` when value differs from default

## Test Plan
- [x] `npm run build` passes
- [x] Prettier formatting verified
- [ ] Field appears in n8n UI under Scrape → Output Options
- [ ] Setting a custom value sends `max_response_bytes` in API request body
- [ ] Setting to 0 sends `max_response_bytes: 0` (no-limit override)

Closes #152