### PR TITLE
Feat: Add Content (AI/KB) format to Scrape and Crawl operations

### DIFF
--- a/nodes/AlterLab/AlterLab.node.ts
+++ b/nodes/AlterLab/AlterLab.node.ts
@@ -255,6 +255,7 @@ export class AlterLab implements INodeType {
             type: "multiOptions",
             default: ["markdown", "json"],
             options: [
+              { name: "Content (AI/KB)", value: "content" },
               { name: "HTML", value: "html" },
               { name: "JSON", value: "json" },
               { name: "JSON V2 (Section Tree)", value: "json_v2" },
@@ -263,7 +264,7 @@ export class AlterLab implements INodeType {
               { name: "Text", value: "text" },
             ],
             description:
-              "Output formats for content transformation. json_v2 returns a structured section tree. rag returns chunked content for vector ingestion.",
+              "Output formats for content transformation. json_v2 returns a structured section tree. rag returns chunked content for vector ingestion. content returns body_markdown + content_hash for AI/KB pipelines.",
           },
           {
             displayName: "Include Raw HTML",
@@ -742,6 +743,7 @@ export class AlterLab implements INodeType {
             type: "multiOptions",
             default: ["markdown"],
             options: [
+              { name: "Content (AI/KB)", value: "content" },
               { name: "HTML", value: "html" },
               { name: "JSON", value: "json" },
               { name: "JSON V2 (Section Tree)", value: "json_v2" },


### PR DESCRIPTION
## Summary

Part of AlterLab/AlterLab#4271 — SDK support for content format.

### Changes
- Add `{ name: "Content (AI/KB)", value: "content" }` to Scrape operation formats multiOptions
- Add `{ name: "Content (AI/KB)", value: "content" }` to Crawl operation formats multiOptions
- Update Scrape operation formats description to mention content format use case

The `content` format returns `body_markdown`, `content_hash`, `images`, and `links` — designed for AI/KB pipeline ingestion and cheap change detection.

## Test plan
- [ ] Scrape operation "Formats" dropdown includes "Content (AI/KB)" option
- [ ] Crawl operation "Formats" dropdown includes "Content (AI/KB)" option
- [ ] Selecting "content" format sends correct value to API