### PR TITLE
Fix: expose use_system_proxy for BYOP proxy override (#219)

### DIFF
--- a/nodes/AlterLab/AlterLab.node.ts
+++ b/nodes/AlterLab/AlterLab.node.ts
@@ -406,6 +406,14 @@ export class AlterLab implements INodeType {
             description: "Whether to route through a premium proxy (+$0.0002)",
           },
           {
+            displayName: "Use System Proxy",
+            name: "useSystemProxy",
+            type: "boolean",
+            default: false,
+            description:
+              "Whether to override your default BYOP (Bring Your Own Proxy) integration and use AlterLab's system proxy for this request instead",
+          },
+          {
             displayName: "Proxy Country",
             name: "proxyCountry",
             type: "string",
@@ -2651,6 +2659,7 @@ export class AlterLab implements INodeType {
           ) as {
             renderJs?: boolean;
             useProxy?: boolean;
+            useSystemProxy?: boolean;
             proxyCountry?: string;
           };
           const costControls = this.getNodeParameter("costControls", i, {}) as {
@@ -2667,6 +2676,7 @@ export class AlterLab implements INodeType {
           const advanced: Record<string, unknown> = {};
           if (advancedOptions.renderJs) advanced.render_js = true;
           if (advancedOptions.useProxy) advanced.use_proxy = true;
+          if (advancedOptions.useSystemProxy) advanced.use_system_proxy = true;
           if (advancedOptions.proxyCountry) {
             advanced.proxy_country = advancedOptions.proxyCountry;
           }
@@ -2756,6 +2766,7 @@ export class AlterLab implements INodeType {
           scrollToLoad?: boolean;
           ocr?: boolean;
           useProxy?: boolean;
+          useSystemProxy?: boolean;
           proxyCountry?: string;
           waitCondition?: string;
           removeCookieBanners?: boolean;
@@ -2827,6 +2838,7 @@ export class AlterLab implements INodeType {
         if (advancedOptions.scrollToLoad) advanced.scroll_to_load = true;
         if (advancedOptions.ocr) advanced.ocr = true;
         if (advancedOptions.useProxy) advanced.use_proxy = true;
+        if (advancedOptions.useSystemProxy) advanced.use_system_proxy = true;
         if (advancedOptions.proxyCountry) {
           advanced.proxy_country = advancedOptions.proxyCountry;
         }


### PR DESCRIPTION
## Summary

Adds `useSystemProxy` boolean to the scrape resource's Advanced Options, exposing the existing `advanced.use_system_proxy` API parameter that was previously inaccessible from n8n.

This parameter allows BYOP (Bring Your Own Proxy) users to override their default proxy integration and force AlterLab's system proxy for specific workflow requests.

## Changes

- `nodes/AlterLab/AlterLab.node.ts`: Added `useSystemProxy` boolean to scrape `advancedOptions` UI collection
- `nodes/AlterLab/AlterLab.node.ts`: Updated TypeScript type declarations for both `scrape` and `estimateCost` operations
- `nodes/AlterLab/AlterLab.node.ts`: Added `advanced.use_system_proxy` body mapping for both operations

## Testing

- [ ] Enable `useSystemProxy` with BYOP proxy active — system proxy should be used
- [ ] Disable `useSystemProxy` — BYOP proxy should be used (default behavior)
- [ ] Non-BYOP user: field has no effect (backend ignores it)
- [ ] `npm run build` passes ✅

---
Closes #219
**Implementation branch**: `fix/scrape-use-system-proxy-219`
**Base**: `main`