### PR TITLE
Fix: restrict Scrape httpMethod to GET/POST to match API schema

### DIFF
--- a/nodes/AlterLab/AlterLab.node.ts
+++ b/nodes/AlterLab/AlterLab.node.ts
@@ -196,25 +196,10 @@ export class AlterLab implements INodeType {
           {
             name: "POST",
             value: "POST",
-            description: "Form submissions, REST APIs, GraphQL",
-          },
-          {
-            name: "PUT",
-            value: "PUT",
-            description: "Full resource replacement",
-          },
-          {
-            name: "PATCH",
-            value: "PATCH",
-            description: "Partial resource update",
-          },
-          {
-            name: "DELETE",
-            value: "DELETE",
-            description: "Resource deletion",
+            description: "Form submissions, REST APIs, GraphQL. POST costs 1.5× the base tier price.",
           },
         ],
-        description: "HTTP method for the target URL request",
+        description: "HTTP method for the target URL request. The AlterLab API supports GET and POST only.",
       },
 
       // ── Request Body ─────────────────────────────────────
@@ -228,7 +213,7 @@ export class AlterLab implements INodeType {
         displayOptions: {
           show: {
             resource: ["scrape"],
-            httpMethod: ["POST", "PUT", "PATCH"],
+            httpMethod: ["POST"],
           },
         },
         description:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-alterlab",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "n8n community node for AlterLab web scraping API — anti-bot bypass, JS rendering, structured extraction, OCR, and more.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary

The AlterLab API's `UnifiedScrapeRequest.method` field is an enum restricted to `GET` and `POST`. The n8n node previously exposed `PUT`, `PATCH`, and `DELETE` as valid HTTP Method options in the Scrape resource — any user selecting these would receive a 422 Unprocessable Entity from the API.

## Changes

- Remove `PUT`, `PATCH`, `DELETE` from the `httpMethod` options array in the Scrape resource
- Update `requestBody` field `displayOptions` to show only for `httpMethod: ["POST"]` (was `["POST", "PUT", "PATCH"]`)
- Improve field descriptions to surface the POST cost multiplier and the GET/POST constraint
- Bump version `0.10.0` → `0.10.1`

## Testing

- [ ] Set httpMethod to POST — confirm requestBody field appears
- [ ] Set httpMethod to GET — confirm requestBody field is hidden
- [ ] POST scrape with JSON body returns scraped content
- [ ] GET scrape returns scraped content

---
Closes #222
**Implementation branch**: `fix/scrape-method-enum-222`
**Base**: `main`