### PR TITLE
Fix: sync content.json extraction_schema response behavior (#225)

### DIFF
--- a/nodes/AlterLab/AlterLab.node.ts
+++ b/nodes/AlterLab/AlterLab.node.ts
@@ -196,10 +196,12 @@ export class AlterLab implements INodeType {
           {
             name: "POST",
             value: "POST",
-            description: "Form submissions, REST APIs, GraphQL. POST costs 1.5× the base tier price.",
+            description:
+              "Form submissions, REST APIs, GraphQL. POST costs 1.5× the base tier price.",
           },
         ],
-        description: "HTTP method for the target URL request. The AlterLab API supports GET and POST only.",
+        description:
+          "HTTP method for the target URL request. The AlterLab API supports GET and POST only.",
       },
 
       // ── Request Body ─────────────────────────────────────
@@ -3052,7 +3054,10 @@ export class AlterLab implements INodeType {
           sizeBytes: (data.size_bytes as number) ?? 0,
         };
 
-        // Flatten multi-format content
+        // Flatten multi-format content.
+        // When extraction_schema is provided, the API overrides content.json
+        // with the filtered/extracted schema result (PR #19898). output.json
+        // therefore carries the extraction result in that case.
         if (content && typeof content === "object") {
           output.markdown =
             (content as Record<string, unknown>).markdown ?? null;
@@ -3065,7 +3070,8 @@ export class AlterLab implements INodeType {
           output.markdown = content ?? null;
         }
 
-        // Extraction results
+        // Extraction results — top-level filtered_content is still returned
+        // by the API alongside the content.json override above.
         output.filteredContent = data.filtered_content ?? null;
         output.extractionMethod = data.extraction_method ?? null;
 


### PR DESCRIPTION
## Summary

API change from PR #19898 (AlterLab backend): when `extraction_schema` is provided, the API now overrides `content.json` with the filtered/extracted schema result. This updates code comments to document the new semantic — no logic change is needed since the node already reads `content.json` correctly.

## Changes

- `nodes/AlterLab/AlterLab.node.ts`: Updated comments in the scrape output formatting block to clarify that `output.json` carries the extraction result when `extraction_schema` is used. `output.filteredContent` remains as a secondary path (top-level `filtered_content` still returned by API).

## Testing

- [x] `npm run build` passes
- [x] Prettier applied
- [x] No merge commits in ancestry

---
Closes #225
Closes #226
**Implementation branch**: `fix/sync-scrape-content-json-225`
**Base**: `main`