### PR TITLE
Fix: clean up 402 error description after API balance exposure removal (#230)

### DIFF
--- a/nodes/AlterLab/AlterLab.node.ts
+++ b/nodes/AlterLab/AlterLab.node.ts
@@ -3286,7 +3286,7 @@ function handleApiError(
     case 402:
       throw new NodeApiError(ctx.getNode(), body, {
         message: "Insufficient balance",
-        description: `${detail}. Top up your balance at https://app.alterlab.io/dashboard/billing?${UTM}`,
+        description: `Top up your balance at https://app.alterlab.io/dashboard/billing?${UTM}`,
         httpCode: "402",
         itemIndex,
       });


### PR DESCRIPTION
## Summary
- API PR #19971 removed exact dollar amounts from 402 insufficient_credits responses
- The 402 error handler in the n8n node was injecting `${detail}` into the description, which now produces a redundant/duplicated "Please top up" message
- Removed the `${detail}.` prefix from the 402 case — description now cleanly links to the billing page

## Changes
- `nodes/AlterLab/AlterLab.node.ts`: Remove `${detail}.` from 402 error description in `handleApiError`

## Testing
- [ ] Trigger a 402 response and verify the error shows "Insufficient balance" with billing URL only
- [ ] Verify 401, 403, 429 error cases still include `detail` in their descriptions

---
Closes #230
**Implementation branch**: `fix/sync-balance-402-error-230`
**Base**: `main`